### PR TITLE
fix: minor bug fixes for previews

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -127,7 +127,7 @@ Here is an overview of the properties that can be used as part of the Front Matt
 | type            | ✅       | `part \| chapter \| lesson` | ❌        | The type of the metadata.                                                                                                                             |
 | title           | ✅       | `string`                    | ❌        | The title of the part, chapter, or lesson.                                                                                                            |
 | slug            |          | `string`                    | ❌        | Let’s you customize the URL pathname which is `/:partSlug/:chapterSlug/:lessonSlug`.                                                                  |
-| previews        |          | `number[]`                  | ✅        | Configure which ports should be used for the previews. If not specified, the lowest port will be used.                                                |
+| previews        |          | `Preview[]`                 | ✅        | Configure which ports should be used for the previews. If not specified, the lowest port will be used.                                                |
 | autoReload      |          | `boolean`                   | ✅        | Navigating to a lesson that specifies `autoReload` will always reload the preview. This is typically only needed if your server does not support HMR. |
 | prepareCommands |          | `Command[]`                 | ✅        | List of commands to execute sequentially. They are typically used to install dependencies or to run scripts.                                          |
 | mainCommand     |          | `Command`                   | ✅        | The main command to be executed. This command will run after the `prepareCommands`.                                                                   |
@@ -139,5 +139,11 @@ string | [command: string, title: string] | { command: string, title: string }
 ```
 
 The title is used as part of the boot screen (see [UI Structure](#ui-structure)).
+
+A `Preview` has the following shape:
+
+```ts
+string | [port: number, title: string] | { port: number, title: string }
+```
 
 In most cases, metadata is inherited. For example, if you specify a `mainCommand` on a chapter without specifying it on any of its lessons, each lesson will use the `mainCommand` from its respective chapter. This extends to chapter and parts as well.

--- a/template/src/components/webcontainer/preview-info.ts
+++ b/template/src/components/webcontainer/preview-info.ts
@@ -28,6 +28,6 @@ export class PreviewInfo {
   }
 
   static equals(a: PreviewInfo, b: PreviewInfo) {
-    return a.port === b.port;
+    return a.port === b.port && a.pathname === b.pathname && a.title === b.title;
   }
 }

--- a/template/src/components/webcontainer/tutorial-runner.ts
+++ b/template/src/components/webcontainer/tutorial-runner.ts
@@ -139,7 +139,7 @@ export class TutorialRunner {
 
     if (!areDifferent) {
       for (let i = 0; i < previewInfos.length; i++) {
-        areDifferent = PreviewInfo.equals(previewInfos[i], this._previewsLayout[i]);
+        areDifferent = !PreviewInfo.equals(previewInfos[i], this._previewsLayout[i]);
 
         if (areDifferent) {
           break;


### PR DESCRIPTION
After this PR, preview titles are correctly updated and we render the correct preview when navigating from one lesson to another that use a different layout for the previews. The current check was missing a negation causing the logic to be skipped in the wrong situations.