### PR TITLE
chore: add project references to improve dx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dist-ssr
 *.sw?
 .pnpm-store
 /tutorialkit/template
+tsconfig.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "build": "pnpm run '--filter=@tutorialkit/*' build",
     "template:dev": "pnpm run build && pnpm run --filter=tutorialkit-starter dev",
     "template:build": "pnpm run build && pnpm run --filter=tutorialkit-starter build",
-    "prepare": "is-ci || husky install"
+    "prepare": "is-ci || husky install",
+    "clean": "./scripts/clean.sh"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/cli/scripts/pre-pack.js
+++ b/packages/cli/scripts/pre-pack.js
@@ -41,6 +41,14 @@ fs.cpSync(path.join(overwritesFolder), path.join(templateDest), {
   recursive: true,
 });
 
+// remove project references from tsconfig.json
+const tsconfigPath = path.join(templateDest, 'tsconfig.json');
+const tsconfig = JSON.parse(fs.readFileSync(tsconfigPath, { encoding: 'utf-8' }));
+
+delete tsconfig.references;
+
+fs.writeFileSync(tsconfigPath, JSON.stringify(tsconfig, undefined, 2));
+
 async function runBuild() {
   const exitCode = await new Promise((resolve) => {
     const child = spawn('node', [path.join(__dirname, './build.js')], {

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
   },
   "include": ["src"]
 }

--- a/packages/template/tsconfig.json
+++ b/packages/template/tsconfig.json
@@ -8,5 +8,6 @@
       "@*": ["src/*"]
     }
   },
-  "exclude": ["dist"]
+  "exclude": ["dist"],
+  "references": [{ "path": "../runtime" }, { "path": "../types" }]
 }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,15 +1,9 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "verbatimModuleSyntax": true,
-    "moduleResolution": "Bundler",
-    "forceConsistentCasingInFileNames": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "strict": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
   },
   "include": ["src"]
 }

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+find . -name "*.tsbuildinfo" -type f -delete
+find packages -maxdepth 2 -name "dist" -type d -exec rm -rf {} +


### PR DESCRIPTION
This PR adds project references to the `template` to improve the development experience when working on `stackblitz/tutorialkit`. This won't have any impact for end users but will make it easier for us to navigate between files & packages.