### PR TITLE
chore: rename terminal to output and refactor terminal component

### DIFF
--- a/packages/components/react/src/Panels/TerminalPanel.tsx
+++ b/packages/components/react/src/Panels/TerminalPanel.tsx
@@ -1,9 +1,14 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
-import type { Props } from '../Terminal';
+import type { TutorialRunner } from '@tutorialkit/runtime';
 
 const Terminal = lazy(() => import('../Terminal/index.js'));
 
-export function TerminalPanel(props: Props) {
+interface TerminalPanelProps {
+  theme: 'dark' | 'light';
+  tutorialRunner: TutorialRunner
+}
+
+export function TerminalPanel({ theme, tutorialRunner }: TerminalPanelProps) {
   const [domLoaded, setDomLoaded] = useState(false);
 
   useEffect(() => {
@@ -14,14 +19,18 @@ export function TerminalPanel(props: Props) {
     <div className="panel-container bg-tk-elements-app-backgroundColor">
       <div className="panel-header border-y border-tk-elements-app-borderColor">
         <div className="panel-title">
-          <div className="panel-icon i-ph-terminal-window-duotone"></div>
-          <span className="text-sm">Terminal</span>
+          <div className="panel-icon i-ph-newspaper-duotone"></div>
+          <span className="text-sm">Output</span>
         </div>
       </div>
       <div className="h-full overflow-hidden">
         {domLoaded && (
           <Suspense>
-            <Terminal {...props} />
+            <Terminal
+              theme={theme}
+              readonly={true}
+              onTerminalReady={(terminal) => tutorialRunner.hookOutputPanel(terminal)}
+              onTerminalResize={() => tutorialRunner.onOutputResize()}/>
           </Suspense>
         )}
       </div>


### PR DESCRIPTION
This PR refactors a bit of the Terminal component. This removes `tutorialRunner` notion from the `Terminal` component so wiring them together now happens in the `TerminalPanel` instead.

I also renamed the bottom panel `Output` with a different icon.

<img width="1069" alt="image" src="https://github.com/stackblitz/tutorialkit/assets/1913805/d7be3486-69f4-4b3a-b8bd-71b4eb47d28b">

This is the setup work that we need in order to support a `Terminal` as well. So we will have 2 tabs, one is `Output` and the other is `Terminal` (in case the lesson needs a terminal).