### PR TITLE
fix(tutorial-runner): do not print empty new line for non-runnable command

### DIFF
--- a/packages/runtime/src/tutorial-runner.ts
+++ b/packages/runtime/src/tutorial-runner.ts
@@ -476,6 +476,9 @@ export class TutorialRunner {
 
       this._stepController.setFromCommands(commandList);
 
+      // keep track of the current runnable command we are on
+      let runnableCommands = 0;
+
       for (const [index, command] of commandList.entries()) {
         const isMainCommand = index === commandList.length - 1 && !!commands.mainCommand;
 
@@ -494,9 +497,11 @@ export class TutorialRunner {
         });
 
         // print newlines between commands to visually separate them from one another
-        if (index > 0) {
+        if (runnableCommands > 0) {
           this._output?.write('\n');
         }
+
+        runnableCommands++;
 
         this._currentCommandProcess = await this._newProcess(webcontainer, command.shellCommand);
 


### PR DESCRIPTION
The problem we saw was that sometimes the terminal printed a newline at the top. Which looked quite off...

After investigating, I found that this was because the first command was a non-runnable command so it skipped it. But then it printed a newline because the index of the next command was greater than 0.