### PR TITLE
fix(cli): remove enterprise question

### DIFF
--- a/packages/cli/src/commands/create/enterprise.ts
+++ b/packages/cli/src/commands/create/enterprise.ts
@@ -1,7 +1,5 @@
-import * as prompts from '@clack/prompts';
 import fs from 'node:fs';
 import path from 'node:path';
-import { assertNotCanceled } from '../../utils/tasks.js';
 import type { CreateOptions } from './options.js';
 import { parseAstroConfig, replaceArgs } from './astro-config.js';
 import { generate } from './babel.js';
@@ -10,26 +8,7 @@ export async function setupEnterpriseConfig(dest: string, flags: CreateOptions) 
   let editorOrigin = flags.enterprise;
 
   if (!flags.defaults && flags.enterprise === undefined) {
-    const answer = await prompts.confirm({
-      message: `TutorialKit uses StackBlitz WebContainers, do you want to configure the Enterprise version?`,
-      initialValue: false,
-    });
-
-    assertNotCanceled(answer);
-
-    if (!answer) {
-      return;
-    }
-
-    const editorURL = await prompts.text({
-      message: `What's the origin of your StackBlitz instance?`,
-      placeholder: 'https://editor.stackblitz.acme.com',
-      validate: validateEditorOrigin,
-    });
-
-    assertNotCanceled(editorURL);
-
-    editorOrigin = new URL(editorURL).origin;
+    return;
   } else if (editorOrigin) {
     const error = validateEditorOrigin(editorOrigin);
 


### PR DESCRIPTION
This PR removes the question about the enterprise and leave it as only an option that can be specified via the `-e, --enterprise` flag.