### PR TITLE
chore: update filter to include tutorialkit cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "pnpm run '--filter=@tutorialkit/*' build",
+    "build": "pnpm run --filter=@tutorialkit/* --filter=tutorialkit build",
     "template:dev": "pnpm run build && pnpm run --filter=tutorialkit-starter dev",
     "template:build": "pnpm run build && pnpm run --filter=tutorialkit-starter build",
     "prepare": "is-ci || husky install",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-pnpm build && pnpm publish --recursive --tag dev --filter "@tutorialkit/*" "$@"
+pnpm build && pnpm publish --recursive --tag dev --filter "@tutorialkit/*" --filter "tutorialkit" "$@"


### PR DESCRIPTION
This PR adds another `--filter` to include the TutorialKit CLI for both the `build` script as well as the `publish` script.