### PR TITLE
fix(cli): fix installing dependencies

### DIFF
--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -129,11 +129,13 @@ async function _createTutorial(flags: CreateOptions) {
 
   await copyTemplate(resolvedDest, flags);
 
+  updatePackageJson(resolvedDest, tutorialName, flags);
+
   const { selectedPackageManager, dependenciesInstalled } = await installDependencies(resolvedDest, flags);
 
-  await setupEnterpriseConfig(resolvedDest, flags);
-  updatePackageJson(resolvedDest, tutorialName, flags);
   updateReadme(resolvedDest, selectedPackageManager, flags);
+
+  await setupEnterpriseConfig(resolvedDest, flags);
 
   await initGitRepo(resolvedDest, flags);
 

--- a/packages/template/.gitignore
+++ b/packages/template/.gitignore
@@ -1,6 +1,6 @@
-dist/
-.astro/
-node_modules/
+dist
+.astro
+node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
@@ -8,4 +8,4 @@ pnpm-debug.log*
 .env
 .env.production
 .DS_Store
-.idea/
+.idea


### PR DESCRIPTION
When I used the cli, I noticed that the `installing dependencies` step was nearly instant, but it actually didn't do anything.

After some debugging, I found out that the child process actually exitted with exit code 0, but still it reported `Dependencies installed`.

After digging deeper, I found out that we didn't update the `package.json` before running `npm install`. This means that the `package.json` still has dependencies which are `workspace:*` instead of the real version.

I also modified the `shell.ts` which spawns the child processes to reject if the child process exits with a code different from `0`. Which would've then reported `Failed to install dependencies. Please run npm install manually after the setup.`.