### PR TITLE
fix: hide terminal by default

### DIFF
--- a/packages/components/react/src/Panels/WorkspacePanel.tsx
+++ b/packages/components/react/src/Panels/WorkspacePanel.tsx
@@ -268,12 +268,12 @@ export function WorkspacePanel({ lesson, tutorialRunner, theme }: Props) {
         />
       </Panel>
       <PanelResizeHandle className={resizePanelStyles.PanelResizeHandle} hitAreaMargins={{ fine: 5, coarse: 5 }} />
-      <Panel defaultSize={25} minSize={10}>
+      <Panel defaultSize={50} minSize={10}>
         <PreviewPanel tutorialRunner={tutorialRunner} ref={previewRef} toggleTerminal={toggleTerminal} />
       </Panel>
       <PanelResizeHandle className={resizePanelStyles.PanelResizeHandle} hitAreaMargins={{ fine: 5, coarse: 5 }} />
       <Panel
-        defaultSize={25}
+        defaultSize={0}
         minSize={10}
         collapsible
         ref={terminalPanelRef}


### PR DESCRIPTION
This PR hides the terminal/output by default. Which was discussed on Slack and I think makes sense.

![image](https://github.com/stackblitz/tutorialkit/assets/1913805/d4e23d14-6f1b-440d-9879-d4ba54952c68)

After toggling, it then looks like it did before

![image](https://github.com/stackblitz/tutorialkit/assets/1913805/ee086881-717b-4c83-bf84-2d7d30e0e7d4)
