### PR TITLE
chore: bump versions

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/astro",
-  "version": "0.0.1-alpha.20",
+  "version": "0.0.1-alpha.21",
   "description": "TutorialKit integration for Astro (https://astro.build)",
   "type": "module",
   "bugs": "https://github.com/stackblitz/tutorialkit/issues",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tutorialkit",
-  "version": "0.0.1-alpha.20",
+  "version": "0.0.1-alpha.21",
   "description": "Interactive tutorials powered by WebContainer API",
   "type": "module",
   "bugs": "https://github.com/stackblitz/tutorialkit/issues",

--- a/packages/components/react/package.json
+++ b/packages/components/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/components-react",
-  "version": "0.0.1-alpha.20",
+  "version": "0.0.1-alpha.21",
   "description": "TutorialKit's React components",
   "type": "module",
   "bugs": "https://github.com/stackblitz/tutorialkit/issues",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/runtime",
-  "version": "0.0.1-alpha.20",
+  "version": "0.0.1-alpha.21",
   "description": "TutorialKit runtime",
   "type": "module",
   "bugs": "https://github.com/stackblitz/tutorialkit/issues",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/types",
-  "version": "0.0.1-alpha.20",
+  "version": "0.0.1-alpha.21",
   "description": "Types for TutorialKit",
   "type": "module",
   "bugs": "https://github.com/stackblitz/tutorialkit/issues",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
-pnpm build && pnpm publish --recursive --tag dev --filter "@tutorialkit/*" --filter "tutorialkit" "$@"
+# if no tag is specified we'll use 'latest' as the default
+TAG=${1:-latest}
+
+pnpm build && pnpm publish --recursive --tag "$TAG" --filter "@tutorialkit/*" --filter "tutorialkit" "$@"


### PR DESCRIPTION
This PR bumps the version of all packages so I can publish the new versions using the `latest` tag instead of the `dev` tag.