### PR TITLE
fix: use part title instead of slug for page title

### DIFF
--- a/packages/astro/src/default/utils/routes.ts
+++ b/packages/astro/src/default/utils/routes.ts
@@ -24,7 +24,7 @@ export async function generateStaticRoutes() {
           },
           props: {
             navList: generateNavigationList(tutorial),
-            title: `${part.slug} / ${chapter.data.title} / ${lesson.data.title}`,
+            title: `${part.data.title} / ${chapter.data.title} / ${lesson.data.title}`,
             lesson: lesson as Lesson<AstroComponentFactory>,
           },
         } satisfies GetStaticPathsItem);


### PR DESCRIPTION
This PR fixes a small bug with the page title where it used the part's `slug` instead of the `title`.

Fixes PRO-2318