### PR TITLE
chore: rename github workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: TutorialKit
+name: CI
 on:
   push:
     branches:


### PR DESCRIPTION
This PR updates the `main` workflow to `ci` cause `main` isn't very descriptive. I noticed this when I wanted to set up required status checks.

This aligns with what other OSS projects do as well, e.g., [vite](https://github.com/vitejs/vite/blob/main/.github/workflows/ci.yml).