### PR TITLE
feat: add MDX extension to `recommendations` in extensions.json

### DIFF
--- a/packages/template/.vscode/extensions.json
+++ b/packages/template/.vscode/extensions.json
@@ -1,4 +1,4 @@
 {
-  "recommendations": ["astro-build.astro-vscode"],
+  "recommendations": ["astro-build.astro-vscode", "unifiedjs.vscode-mdx"],
   "unwantedRecommendations": []
 }


### PR DESCRIPTION
As the [documentation](https://tutorialkit.dev/guides/installation/#editor-configuration) recommends using the [MDX extension](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx), I have added it to the recommendations section in the extensions.json file of the template.