### PR TITLE
fix: sort navigation items numerically in `objectToSortedArray` function

### DIFF
--- a/.changeset/smooth-camels-fail.md
+++ b/.changeset/smooth-camels-fail.md
@@ -1,0 +1,5 @@
+---
+"@tutorialkit/astro": patch
+---
+
+fix: sort navigation items numerically in `objectToSortedArray` function

--- a/packages/astro/src/default/utils/nav.ts
+++ b/packages/astro/src/default/utils/nav.ts
@@ -24,6 +24,6 @@ export function generateNavigationList(tutorial: Tutorial): NavList {
 
 function objectToSortedArray<T extends Record<any, any>>(object: T): Array<T[keyof T]> {
   return Object.keys(object)
-    .sort()
+    .sort((a, b) => Number(a) - Number(b))
     .map((key) => object[key]);
 }


### PR DESCRIPTION
I discovered a bug where parts, chapters, and lessons in navList were being sorted by comparing numbers as strings, causing issues like Chapter 10 being placed before Chapter 2.

Reproduction: https://stackblitz.com/~/github.com/morinokami/tutorialkit-sort-problem

I have fixed this by comparing each key as a numeric value in the objectToSortedArray function.