### PR TITLE
feat: set default package manager to the one used with `create` command

### DIFF
--- a/.changeset/fast-socks-cough.md
+++ b/.changeset/fast-socks-cough.md
@@ -1,0 +1,5 @@
+---
+"tutorialkit": patch
+---
+
+feat: set default package manager to the one used with `create` command

--- a/packages/cli/src/commands/create/dependencies.ts
+++ b/packages/cli/src/commands/create/dependencies.ts
@@ -77,6 +77,7 @@ async function getPackageManager() {
   const installedPackageManagers = await getInstalledPackageManagers();
 
   let initialValue = process.env.npm_config_user_agent?.split('/')[0] as PackageManager | undefined;
+
   if (!installedPackageManagers.includes(initialValue)) {
     initialValue = 'npm';
   }

--- a/packages/cli/src/commands/create/dependencies.ts
+++ b/packages/cli/src/commands/create/dependencies.ts
@@ -76,7 +76,10 @@ export async function installDependencies(cwd: string, flags: CreateOptions) {
 async function getPackageManager() {
   const installedPackageManagers = await getInstalledPackageManagers();
 
-  const initialValue = process.env.npm_config_user_agent?.split('/')[0] ?? 'npm';
+  let initialValue = process.env.npm_config_user_agent?.split('/')[0] as PackageManager | undefined;
+  if (!installedPackageManagers.includes(initialValue)) {
+    initialValue = 'npm';
+  }
 
   const answer = await prompts.select({
     message: 'What package manager should we use?',

--- a/packages/cli/src/commands/create/dependencies.ts
+++ b/packages/cli/src/commands/create/dependencies.ts
@@ -76,9 +76,11 @@ export async function installDependencies(cwd: string, flags: CreateOptions) {
 async function getPackageManager() {
   const installedPackageManagers = await getInstalledPackageManagers();
 
+  const initialValue = process.env.npm_config_user_agent?.split('/')[0] ?? 'npm';
+
   const answer = await prompts.select({
     message: 'What package manager should we use?',
-    initialValue: 'pnpm',
+    initialValue,
     options: [
       { label: 'npm', value: 'npm' },
       ...installedPackageManagers.map((pkgManager) => {


### PR DESCRIPTION
Currently, when creating a project using a command like `npm create tutorial`, the default package manager for installing dependencies is [hardcoded to pnpm](https://github.com/stackblitz/tutorialkit/blob/94546823c3393e4d3005ff78038119692475466b/packages/cli/src/commands/create/dependencies.ts#L81). However, it seems more intuitive to use the package manager that was used to run the create command as the default. This PR makes that change. Additionally, if the package manager cannot be determined, the fallback default is set to npm.