### PR TITLE
refactor: move runtime logic in TutorialStore

### DIFF
--- a/packages/astro/src/css.ts
+++ b/packages/astro/src/css.ts
@@ -9,7 +9,7 @@
 import { watch } from 'chokidar';
 import fs from 'fs/promises';
 import path from 'path';
-import type { ViteDevServer, VitePlugin } from './types';
+import type { ViteDevServer, VitePlugin } from './types.js';
 import type { AstroIntegrationLogger } from 'astro';
 
 const CUSTOM_PATHS = ['theme.css', 'theme/index.css'];

--- a/packages/astro/src/default/components/WorkspacePanelWrapper.tsx
+++ b/packages/astro/src/default/components/WorkspacePanelWrapper.tsx
@@ -1,8 +1,8 @@
 import { useStore } from '@nanostores/react';
 import { WorkspacePanel } from '@tutorialkit/components-react';
 import type { Lesson } from '@tutorialkit/types';
-import { themeStore } from '../stores/theme-store';
-import { tutorialRunner } from './webcontainer';
+import { themeStore } from '../stores/theme-store.js';
+import { tutorialStore } from './webcontainer.js';
 
 interface Props {
   lesson: Lesson;
@@ -11,5 +11,7 @@ interface Props {
 export function WorkspacePanelWrapper({ lesson }: Props) {
   const theme = useStore(themeStore);
 
-  return <WorkspacePanel lesson={lesson} tutorialRunner={tutorialRunner} theme={theme} />;
+  tutorialStore.setLesson(lesson, { ssr: import.meta.env.SSR });
+
+  return <WorkspacePanel tutorialStore={tutorialStore} theme={theme} />;
 }

--- a/packages/astro/src/default/components/setup.ts
+++ b/packages/astro/src/default/components/setup.ts
@@ -3,7 +3,7 @@
  * This ensures that when the authentication flow is complete in a popup, the popup is closed quickly.
  */
 import { auth } from '@webcontainer/api';
-import { authStore } from '../stores/auth-store';
+import { authStore } from '../stores/auth-store.js';
 
 const authConfig = __WC_CONFIG__;
 

--- a/packages/astro/src/default/components/webcontainer.ts
+++ b/packages/astro/src/default/components/webcontainer.ts
@@ -1,6 +1,6 @@
-import { useAuth } from './setup';
+import { useAuth } from './setup.js';
 import { auth, WebContainer } from '@webcontainer/api';
-import { TutorialRunner } from '@tutorialkit/runtime';
+import { TutorialStore } from '@tutorialkit/runtime';
 
 interface WebContainerContext {
   useAuth: boolean;
@@ -20,7 +20,7 @@ if (!import.meta.env.SSR) {
   });
 }
 
-export const tutorialRunner = new TutorialRunner(webcontainer, useAuth);
+export const tutorialStore = new TutorialStore({ webcontainer, useAuth });
 
 export async function login() {
   auth.startAuthFlow({ popup: true });

--- a/packages/astro/tsconfig.json
+++ b/packages/astro/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "react",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/components/react/scripts/build.js
+++ b/packages/components/react/scripts/build.js
@@ -4,7 +4,16 @@ import { cp } from 'fs/promises';
 import { join } from 'path';
 
 // build everything with typescript
-spawnSync('tsc', ['-b'], { stdio: 'inherit' });
+const { status, error } = spawnSync('tsc', ['-b'], { stdio: 'inherit' });
+
+if (error) {
+  console.error(error);
+  process.exit(1);
+}
+
+if (status !== 0) {
+  process.exit(status);
+}
 
 // copy css files unmodified
 const filePaths = fastGlob.globSync(`./src/**/*.css`, {

--- a/packages/components/react/src/BootScreen.tsx
+++ b/packages/components/react/src/BootScreen.tsx
@@ -1,14 +1,14 @@
 import { useStore } from '@nanostores/react';
-import type { Step, TutorialRunner } from '@tutorialkit/runtime';
+import type { Step, TutorialStore } from '@tutorialkit/runtime';
 import { classNames } from './utils/classnames.js';
 
 interface Props {
   className?: string;
-  tutorialRunner: TutorialRunner;
+  tutorialStore: TutorialStore;
 }
 
-export function BootScreen({ className, tutorialRunner }: Props) {
-  const steps = useStore(tutorialRunner.steps);
+export function BootScreen({ className, tutorialStore }: Props) {
+  const steps = useStore(tutorialStore.steps);
 
   return (
     <div

--- a/packages/components/react/src/CodeMirrorEditor/cm-theme.ts
+++ b/packages/components/react/src/CodeMirrorEditor/cm-theme.ts
@@ -2,7 +2,7 @@ import { defaultHighlightStyle, syntaxHighlighting } from '@codemirror/language'
 import { Compartment, type Extension } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import '../styles/cm.css';
-import type { Theme } from '../types';
+import type { Theme } from '../types.js';
 import { vscodeDarkTheme } from './themes/vscode-dark.js';
 
 export const darkTheme = EditorView.theme({}, { dark: true });

--- a/packages/components/react/src/CodeMirrorEditor/index.tsx
+++ b/packages/components/react/src/CodeMirrorEditor/index.tsx
@@ -14,7 +14,7 @@ import {
   scrollPastEnd,
 } from '@codemirror/view';
 import { useEffect, useRef, useState, type MutableRefObject } from 'react';
-import type { Theme } from '../types';
+import type { Theme } from '../types.js';
 import { debounce } from '../utils/debounce.js';
 import { BinaryContent } from './BinaryContent.js';
 import { getTheme, reconfigureTheme } from './cm-theme.js';
@@ -46,7 +46,7 @@ export type OnChangeCallback = (update: EditorUpdate) => void;
 export type OnScrollCallback = (position: ScrollPosition) => void;
 
 interface Props {
-  reset?: unknown;
+  id?: unknown;
   doc?: EditorDocument;
   debounceChange?: number;
   debounceScroll?: number;
@@ -59,7 +59,7 @@ interface Props {
 type EditorStates = Map<string, EditorState>;
 
 export function CodeMirrorEditor({
-  reset,
+  id,
   doc,
   debounceScroll = 100,
   debounceChange = 150,
@@ -143,7 +143,7 @@ export function CodeMirrorEditor({
 
   useEffect(() => {
     editorStatesRef.current = new Map<string, EditorState>();
-  }, [reset]);
+  }, [id]);
 
   useEffect(() => {
     const editorStates = editorStatesRef.current!;

--- a/packages/components/react/src/FileTree.tsx
+++ b/packages/components/react/src/FileTree.tsx
@@ -7,14 +7,14 @@ const DEFAULT_HIDDEN_FILES = [/\/node_modules\//];
 interface Props {
   files: string[];
   selectedFile?: string;
-  onFileClick: (filePath: string) => void;
+  onFileSelect?: (filePath: string) => void;
   hideRoot: boolean;
   scope?: string;
   hiddenFiles?: Array<string | RegExp>;
   className?: string;
 }
 
-export function FileTree({ files, onFileClick, selectedFile, hideRoot, scope, hiddenFiles, className }: Props) {
+export function FileTree({ files, onFileSelect, selectedFile, hideRoot, scope, hiddenFiles, className }: Props) {
   const computedHiddenFiles = useMemo(() => [...DEFAULT_HIDDEN_FILES, ...(hiddenFiles ?? [])], [hiddenFiles]);
 
   const fileList = useMemo(
@@ -82,7 +82,7 @@ export function FileTree({ files, onFileClick, selectedFile, hideRoot, scope, hi
                 key={fileOrFolder.id}
                 selected={selectedFile === fileOrFolder.fullPath}
                 file={fileOrFolder}
-                onClick={() => onFileClick(fileOrFolder.fullPath)}
+                onClick={() => onFileSelect?.(fileOrFolder.fullPath)}
               />
             );
           case 'folder':

--- a/packages/components/react/src/Panels/EditorPanel.tsx
+++ b/packages/components/react/src/Panels/EditorPanel.tsx
@@ -9,48 +9,42 @@ import {
 } from '../CodeMirrorEditor/index.js';
 import { FileTree } from '../FileTree.js';
 import resizePanelStyles from '../styles/resize-panel.module.css';
-import type { Theme } from '../types';
+import type { Theme } from '../types.js';
 
 const DEFAULT_FILE_TREE_SIZE = 25;
 
 interface Props {
   theme: Theme;
-  lesson: Lesson;
+  id: unknown;
+  files: string[];
+  hideRoot?: boolean;
+  fileTreeScope?: string;
   showFileTree?: boolean;
   helpAction?: 'solve' | 'reset';
   editorDocument?: EditorDocument;
+  selectedFile?: string | undefined;
   onEditorChange?: OnEditorChange;
   onEditorScroll?: OnEditorScroll;
   onHelpClick?: () => void;
-  onFileClick?: (value?: string) => void;
+  onFileSelect?: (value?: string) => void;
 }
 
 export function EditorPanel({
   theme,
-  lesson,
+  id,
+  files,
+  hideRoot,
+  fileTreeScope,
   showFileTree = true,
   helpAction,
   editorDocument,
+  selectedFile,
   onEditorChange,
   onEditorScroll,
   onHelpClick,
-  onFileClick,
+  onFileSelect,
 }: Props) {
   const fileTreePanelRef = useRef<ImperativePanelHandle>(null);
-  const [selectedFile, setSelectedFile] = useState(lesson.data.focus);
-
-  const onFileClickWrapped = useCallback(
-    (fullPath: string) => {
-      setSelectedFile(fullPath);
-      onFileClick?.(fullPath);
-    },
-    [onFileClick],
-  );
-
-  // when the lesson changes we reset the selected file
-  useEffect(() => {
-    setSelectedFile(lesson.data.focus);
-  }, [lesson]);
 
   useEffect(() => {
     const { current: fileTreePanel } = fileTreePanelRef;
@@ -66,7 +60,7 @@ export function EditorPanel({
     } else if (!showFileTree) {
       fileTreePanel.collapse();
     }
-  }, [lesson]);
+  }, [id]);
 
   return (
     <PanelGroup className="bg-tk-elements-app-backgroundColor" direction="horizontal">
@@ -80,10 +74,10 @@ export function EditorPanel({
         <FileTree
           className="flex-grow py-2 border-r border-tk-elements-app-borderColor text-sm"
           selectedFile={selectedFile}
-          hideRoot={lesson.data.hideRoot ?? true}
-          files={lesson.files[1]}
-          scope={lesson.data.scope}
-          onFileClick={onFileClickWrapped}
+          hideRoot={hideRoot ?? true}
+          files={files}
+          scope={fileTreeScope}
+          onFileSelect={onFileSelect}
         />
       </Panel>
       <PanelResizeHandle
@@ -96,7 +90,7 @@ export function EditorPanel({
         <div className="h-full flex-1 overflow-hidden">
           <CodeMirrorEditor
             theme={theme}
-            reset={lesson}
+            id={id}
             doc={editorDocument}
             autoFocusOnDocumentChange={true}
             onScroll={onEditorScroll}

--- a/packages/components/react/src/Panels/PreviewPanel.tsx
+++ b/packages/components/react/src/Panels/PreviewPanel.tsx
@@ -1,5 +1,5 @@
 import { BootScreen } from '../BootScreen.js';
-import type { PreviewInfo, TutorialRunner } from '@tutorialkit/runtime';
+import type { PreviewInfo, TutorialStore } from '@tutorialkit/runtime';
 import { useStore } from '@nanostores/react';
 import resizePanelStyles from '../styles/resize-panel.module.css';
 import { classNames } from '../utils/classnames.js';
@@ -9,7 +9,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 interface Props {
   showToggleTerminal?: boolean;
   toggleTerminal?: () => void;
-  tutorialRunner: TutorialRunner;
+  tutorialStore: TutorialStore;
 }
 
 const previewsContainer = globalThis.document ? document.getElementById('previews-container')! : ({} as HTMLElement);
@@ -21,8 +21,8 @@ export type ImperativePreviewHandle = {
 };
 
 export const PreviewPanel = memo(
-  forwardRef<ImperativePreviewHandle, Props>(({ showToggleTerminal, toggleTerminal, tutorialRunner }, ref) => {
-    const expectedPreviews = useStore(tutorialRunner.previews);
+  forwardRef<ImperativePreviewHandle, Props>(({ showToggleTerminal, toggleTerminal, tutorialStore }, ref) => {
+    const expectedPreviews = useStore(tutorialStore.previews);
     const iframeRefs = useRef<IFrameRef[]>([]);
 
     const onResize = useCallback(() => {
@@ -90,7 +90,7 @@ export const PreviewPanel = memo(
               </button>
             )}
           </div>
-          <BootScreen tutorialRunner={tutorialRunner} />
+          <BootScreen tutorialStore={tutorialStore} />
         </div>
       );
     }

--- a/packages/components/react/src/Panels/TerminalPanel.tsx
+++ b/packages/components/react/src/Panels/TerminalPanel.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { useStore } from '@nanostores/react';
-import type { TutorialRunner } from '@tutorialkit/runtime';
+import type { TutorialStore } from '@tutorialkit/runtime';
 import type { TerminalPanelType } from '@tutorialkit/types';
 import { classNames } from '../utils/classnames.js';
 
@@ -8,7 +8,7 @@ const Terminal = lazy(() => import('../Terminal/index.js'));
 
 interface TerminalPanelProps {
   theme: 'dark' | 'light';
-  tutorialRunner: TutorialRunner;
+  tutorialStore: TutorialStore;
 }
 
 const ICON_MAP = new Map<TerminalPanelType, string>([
@@ -16,8 +16,8 @@ const ICON_MAP = new Map<TerminalPanelType, string>([
   ['terminal', 'i-ph-terminal-window-duotone'],
 ]);
 
-export function TerminalPanel({ theme, tutorialRunner }: TerminalPanelProps) {
-  const terminalConfig = useStore(tutorialRunner.terminalConfig);
+export function TerminalPanel({ theme, tutorialStore }: TerminalPanelProps) {
+  const terminalConfig = useStore(tutorialStore.terminalConfig);
 
   const [domLoaded, setDomLoaded] = useState(false);
 
@@ -86,10 +86,10 @@ export function TerminalPanel({ theme, tutorialRunner }: TerminalPanelProps) {
                 theme={theme}
                 readonly={type === 'output'}
                 onTerminalReady={(terminal) => {
-                  tutorialRunner.attachTerminal(id, terminal);
+                  tutorialStore.attachTerminal(id, terminal);
                 }}
                 onTerminalResize={(cols, rows) => {
-                  tutorialRunner.onTerminalResize(cols, rows);
+                  tutorialStore.onTerminalResize(cols, rows);
                 }}
               />
             ))}

--- a/packages/components/react/src/index.ts
+++ b/packages/components/react/src/index.ts
@@ -6,5 +6,5 @@ export * from './Panels/EditorPanel.js';
 export * from './Panels/PreviewPanel.js';
 export * from './Panels/TerminalPanel.js';
 export * from './Panels/WorkspacePanel.js';
-export type * from './types';
+export type * from './types.js';
 export * from './utils/classnames.js';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,3 +1,4 @@
-export { lessonFilesFetcher } from './lesson-files.js';
+export { LessonFilesFetcher } from './lesson-files.js';
 export { TutorialRunner } from './tutorial-runner.js';
-export type { Command, Commands, PreviewInfo, Step, Steps } from './webcontainer';
+export type { Command, Commands, PreviewInfo, Step, Steps } from './webcontainer/index.js';
+export { TutorialStore } from './store/index.js';

--- a/packages/runtime/src/lesson-files.ts
+++ b/packages/runtime/src/lesson-files.ts
@@ -105,8 +105,6 @@ export class LessonFilesFetcher {
   }
 }
 
-export const lessonFilesFetcher = new LessonFilesFetcher();
-
 function convertToFiles(json: Record<string, string | { base64: string }>): Files {
   const result: Files = {};
 

--- a/packages/runtime/src/store/editor.ts
+++ b/packages/runtime/src/store/editor.ts
@@ -1,0 +1,98 @@
+import type { FilesRef, Files } from '@tutorialkit/types';
+import { atom, computed } from 'nanostores';
+
+export interface EditorDocument {
+  value: string | Uint8Array;
+  loading: boolean;
+  filePath: string;
+  scroll?: ScrollPosition;
+}
+
+export interface ScrollPosition {
+  top: number;
+  left: number;
+}
+
+export type EditorDocuments = Record<string, EditorDocument>;
+
+export class EditorStore {
+  selectedFile = atom<string | undefined>();
+  documents = atom<EditorDocuments>({});
+
+  currentDocument = computed([this.documents, this.selectedFile], (documents, selectedFile) => {
+    if (!selectedFile) {
+      return undefined;
+    }
+
+    return documents[selectedFile];
+  });
+
+  setSelectedFile(filePath: string | undefined) {
+    this.selectedFile.set(filePath);
+  }
+
+  setDocuments(files: FilesRef | Files) {
+    // check if it is a FilesRef
+    if (Array.isArray(files)) {
+      this.documents.set(
+        Object.fromEntries(
+          files[1].map((filePath) => {
+            return [
+              filePath,
+              {
+                value: '',
+                loading: true,
+                filePath,
+              },
+            ];
+          }),
+        ),
+      );
+    } else {
+      const previousDocuments = this.documents.value;
+
+      this.documents.set(
+        Object.fromEntries(
+          Object.entries(files).map(([filePath, value]) => {
+            return [
+              filePath,
+              {
+                value,
+                loading: false,
+                filePath,
+                scroll: previousDocuments?.[filePath]?.scroll,
+              },
+            ];
+          }),
+        ) satisfies EditorDocuments,
+      );
+    }
+  }
+
+  updateScrollPosition(filePath: string, position: ScrollPosition) {
+    const documentState = this.documents.get()[filePath];
+
+    if (!documentState) {
+      return;
+    }
+
+    documentState.scroll = position;
+  }
+
+  updateFile(filePath: string, content: string): boolean {
+    const documentState = this.documents.get()[filePath];
+
+    if (!documentState) {
+      return false;
+    }
+
+    const currentContent = documentState.value;
+    const contentChanged = currentContent !== content;
+
+    if (contentChanged) {
+      documentState.value = content;
+    }
+
+    return contentChanged;
+  }
+}

--- a/packages/runtime/src/store/index.ts
+++ b/packages/runtime/src/store/index.ts
@@ -145,8 +145,6 @@ export class TutorialStore {
       return false;
     }
 
-    // TODO: move to EditorStore
-
     const { editor } = this._lesson.data;
 
     return editor === undefined || editor === true || (editor !== false && editor?.fileTree !== false);
@@ -157,8 +155,6 @@ export class TutorialStore {
       return false;
     }
 
-    // TODO: move to EditorStore
-
     const { editor } = this._lesson.data;
 
     return editor !== false;
@@ -168,8 +164,6 @@ export class TutorialStore {
     if (!this._lesson) {
       return false;
     }
-
-    // TODO: move to EditorStore
 
     const { previews } = this._lesson.data;
 

--- a/packages/runtime/src/store/index.ts
+++ b/packages/runtime/src/store/index.ts
@@ -1,0 +1,257 @@
+import type { Files, Lesson } from '@tutorialkit/types';
+import type { WebContainer } from '@webcontainer/api';
+import { atom, type ReadableAtom } from 'nanostores';
+import { LessonFilesFetcher } from '../lesson-files.js';
+import { newTask, type Task } from '../tasks.js';
+import { TutorialRunner } from '../tutorial-runner.js';
+import type { ITerminal } from '../utils/terminal.js';
+import type { PreviewInfo } from '../webcontainer/preview-info.js';
+import { StepsController } from '../webcontainer/steps.js';
+import type { TerminalConfig } from '../webcontainer/terminal-config.js';
+import { EditorStore, type EditorDocument, type EditorDocuments, type ScrollPosition } from './editor.js';
+import { PreviewsStore } from './previews.js';
+import { TerminalStore } from './terminal.js';
+
+interface StoreOptions {
+  webcontainer: Promise<WebContainer>;
+  useAuth: boolean;
+}
+
+export class TutorialStore {
+  private _webcontainer: Promise<WebContainer>;
+
+  private _runner: TutorialRunner;
+  private _previewsStore: PreviewsStore;
+  private _editorStore: EditorStore;
+  private _terminalStore: TerminalStore;
+
+  private _stepController = new StepsController();
+  private _lessonFilesFetcher = new LessonFilesFetcher();
+  private _lessonTask: Task<unknown> | undefined;
+  private _lesson: Lesson | undefined;
+  private _ref: number = 1;
+
+  private _lessonFiles: Files | undefined;
+  private _lessonSolution: Files | undefined;
+
+  /**
+   * Whether or not the current lesson is fully loaded in WebContainer
+   * and in every stores.
+   */
+  readonly lessonFullyLoaded = atom<boolean>(false);
+
+  constructor({ useAuth, webcontainer }: StoreOptions) {
+    this._webcontainer = webcontainer;
+    this._editorStore = new EditorStore();
+    this._previewsStore = new PreviewsStore(this._webcontainer);
+    this._terminalStore = new TerminalStore(this._webcontainer, useAuth);
+    this._runner = new TutorialRunner(this._webcontainer, this._terminalStore, this._stepController);
+  }
+
+  setLesson(lesson: Lesson, options: { ssr?: boolean } = {}) {
+    if (lesson === this._lesson) {
+      return;
+    }
+
+    this._lessonTask?.cancel();
+
+    this._ref += 1;
+    this._lesson = lesson;
+    this.lessonFullyLoaded.set(false);
+
+    this._previewsStore.setPreviews(lesson.data.previews ?? true);
+    this._terminalStore.setTerminalConfiguration(lesson.data.terminal);
+    this._editorStore.setDocuments(lesson.files);
+
+    if (options.ssr) {
+      return;
+    }
+
+    this._lessonTask = newTask(
+      async (signal) => {
+        const templatePromise = this._lessonFilesFetcher.getLessonTemplate(lesson);
+        const filesPromise = this._lessonFilesFetcher.getLessonFiles(lesson);
+
+        const preparePromise = this._runner.prepareFiles({ template: templatePromise, files: filesPromise, signal });
+
+        this._runner.runCommands(lesson.data);
+
+        const [template, solution, files] = await Promise.all([
+          templatePromise,
+          this._lessonFilesFetcher.getLessonSolution(lesson),
+          filesPromise,
+        ]);
+
+        signal.throwIfAborted();
+
+        this._lessonFiles = files;
+        this._lessonSolution = solution;
+
+        this._editorStore.setDocuments(files);
+
+        if (lesson.data.focus === undefined) {
+          this._editorStore.setSelectedFile(undefined);
+        } else if (files[lesson.data.focus] !== undefined) {
+          this._editorStore.setSelectedFile(lesson.data.focus);
+        }
+
+        await preparePromise;
+
+        signal.throwIfAborted();
+
+        this.lessonFullyLoaded.set(true);
+      },
+      { ignoreCancel: true },
+    );
+  }
+
+  get previews(): ReadableAtom<PreviewInfo[]> {
+    return this._previewsStore.previews;
+  }
+
+  get terminalConfig(): ReadableAtom<TerminalConfig> {
+    return this._terminalStore.terminalConfig;
+  }
+
+  get currentDocument(): ReadableAtom<EditorDocument | undefined> {
+    return this._editorStore.currentDocument;
+  }
+
+  get documents(): ReadableAtom<EditorDocuments> {
+    return this._editorStore.documents;
+  }
+
+  get selectedFile(): ReadableAtom<string | undefined> {
+    return this._editorStore.selectedFile;
+  }
+
+  get lesson(): Readonly<Lesson> | undefined {
+    return this._lesson;
+  }
+
+  get ref(): unknown {
+    return this._ref;
+  }
+
+  /**
+   * Steps that the runner is or will be executing.
+   */
+  get steps() {
+    return this._stepController.steps;
+  }
+
+  hasFileTree(): boolean {
+    if (!this._lesson) {
+      return false;
+    }
+
+    // TODO: move to EditorStore
+
+    const { editor } = this._lesson.data;
+
+    return editor === undefined || editor === true || (editor !== false && editor?.fileTree !== false);
+  }
+
+  hasEditor(): boolean {
+    if (!this._lesson) {
+      return false;
+    }
+
+    // TODO: move to EditorStore
+
+    const { editor } = this._lesson.data;
+
+    return editor !== false;
+  }
+
+  hasPreviews(): boolean {
+    if (!this._lesson) {
+      return false;
+    }
+
+    // TODO: move to EditorStore
+
+    const { previews } = this._lesson.data;
+
+    return previews !== false;
+  }
+
+  hasTerminalPanel(): boolean {
+    return this._terminalStore.hasTerminalPanel();
+  }
+
+  hasSolution(): boolean {
+    return !!this._lesson && Object.keys(this._lesson.solution).length >= 1;
+  }
+
+  reset() {
+    const isReady = this.lessonFullyLoaded.value;
+
+    if (!isReady || !this._lessonFiles) {
+      return;
+    }
+
+    this._editorStore.setDocuments(this._lessonFiles);
+    this._runner.updateFiles(this._lessonFiles);
+  }
+
+  solve() {
+    const isReady = this.lessonFullyLoaded.value;
+
+    if (!isReady || !this._lessonSolution) {
+      return;
+    }
+
+    this._editorStore.setDocuments(this._lessonSolution);
+    this._runner.updateFiles(this._lessonSolution);
+  }
+
+  setSelectedFile(filePath: string | undefined) {
+    this._editorStore.setSelectedFile(filePath);
+  }
+
+  updateFile(filePath: string, content: string) {
+    const hasChanged = this._editorStore.updateFile(filePath, content);
+
+    if (hasChanged) {
+      this._runner.updateFile(filePath, content);
+    }
+  }
+
+  updateFiles(files: Files) {
+    this._runner.updateFiles(files);
+  }
+
+  setCurrentDocumentContent(newContent: string) {
+    const filePath = this.currentDocument.get()?.filePath;
+
+    if (!filePath) {
+      return;
+    }
+
+    this.updateFile(filePath, newContent);
+  }
+
+  setCurrentDocumentScrollPosition(position: ScrollPosition) {
+    const editorDocument = this.currentDocument.get();
+
+    if (!editorDocument) {
+      return;
+    }
+
+    const { filePath } = editorDocument;
+
+    this._editorStore.updateScrollPosition(filePath, position);
+  }
+
+  attachTerminal(id: string, terminal: ITerminal) {
+    this._terminalStore.attachTerminal(id, terminal);
+  }
+
+  onTerminalResize(cols: number, rows: number) {
+    if (cols && rows) {
+      this._terminalStore.onTerminalResize(cols, rows);
+      this._runner.onTerminalResize(cols, rows);
+    }
+  }
+}

--- a/packages/runtime/src/store/previews.ts
+++ b/packages/runtime/src/store/previews.ts
@@ -1,0 +1,104 @@
+import type { PreviewSchema } from '@tutorialkit/types';
+import { atom } from 'nanostores';
+import { PreviewInfo } from '../webcontainer/preview-info.js';
+import type { WebContainer } from '@webcontainer/api';
+
+export class PreviewsStore {
+  private _availablePreviews = new Map<number, PreviewInfo>();
+  private _previewsLayout: PreviewInfo[] = [];
+
+  /**
+   * Atom representing the current previews. If it's an empty array or none of
+   * the previews are ready, then no preview can be shown.
+   */
+  previews = atom<PreviewInfo[]>([]);
+
+  constructor(webcontainerPromise: Promise<WebContainer>) {
+    this.init(webcontainerPromise);
+  }
+
+  private async init(webcontainerPromise: Promise<WebContainer>) {
+    const webcontainer = await webcontainerPromise;
+
+    webcontainer.on('port', (port, type, url) => {
+      let previewInfo = this._availablePreviews.get(port);
+
+      if (!previewInfo) {
+        previewInfo = new PreviewInfo(port, type === 'open');
+        this._availablePreviews.set(port, previewInfo);
+      }
+
+      previewInfo.ready = type === 'open';
+      previewInfo.baseUrl = url;
+
+      if (this._previewsLayout.length === 0) {
+        this.previews.set([previewInfo]);
+      } else {
+        this._previewsLayout = [...this._previewsLayout];
+        this.previews.set(this._previewsLayout);
+      }
+    });
+  }
+
+  /**
+   * Set the expected port for the preview to show. If this is not set,
+   * the port of the first server that is ready will be used.
+   */
+  setPreviews(config: PreviewSchema) {
+    if (config === false) {
+      // clear the previews if they are turned off
+      this.previews.set([]);
+
+      return;
+    }
+
+    // if the schema is `true`, we just use the default empty array
+    const previews = config === true ? [] : config ?? [];
+
+    const previewInfos = previews.map((preview) => {
+      const info = new PreviewInfo(preview);
+
+      let previewInfo = this._availablePreviews.get(info.port);
+
+      if (!previewInfo) {
+        previewInfo = info;
+
+        this._availablePreviews.set(previewInfo.port, previewInfo);
+      } else {
+        previewInfo.title = info.title;
+      }
+
+      return previewInfo;
+    });
+
+    let areDifferent = previewInfos.length != this._previewsLayout.length;
+
+    if (!areDifferent) {
+      for (let i = 0; i < previewInfos.length; i++) {
+        areDifferent = !PreviewInfo.equals(previewInfos[i], this._previewsLayout[i]);
+
+        if (areDifferent) {
+          break;
+        }
+      }
+    }
+
+    if (!areDifferent) {
+      return;
+    }
+
+    this._previewsLayout = previewInfos;
+
+    /**
+     * If a port is provided and the preview is already ready we update the previewUrl.
+     * If no port is provided we default to the first preview ever to ready if there are any.
+     */
+    if (previews.length === 0) {
+      const firstPreview = this._availablePreviews.values().next().value as PreviewInfo | undefined;
+
+      this.previews.set(firstPreview ? [firstPreview] : []);
+    } else {
+      this.previews.set(this._previewsLayout);
+    }
+  }
+}

--- a/packages/runtime/src/store/terminal.ts
+++ b/packages/runtime/src/store/terminal.ts
@@ -1,0 +1,162 @@
+import type { TerminalSchema } from '@tutorialkit/types';
+import { WebContainer, auth } from '@webcontainer/api';
+import { atom } from 'nanostores';
+import { tick } from '../utils/promises.js';
+import { isWebContainerSupported } from '../utils/support.js';
+import { clearTerminal, escapeCodes, type ITerminal } from '../utils/terminal.js';
+import { newJSHProcess } from '../webcontainer/shell.js';
+import { TerminalConfig, TerminalPanel } from '../webcontainer/terminal-config.js';
+
+export class TerminalStore {
+  terminalConfig = atom<TerminalConfig>(new TerminalConfig());
+
+  private _output: ITerminal | undefined = undefined;
+  private _webcontainerLoaded = false;
+
+  constructor(
+    private _webcontainer: Promise<WebContainer>,
+    private _useAuth: boolean,
+  ) {
+    this._webcontainer.then(() => {
+      this._webcontainerLoaded = true;
+    });
+  }
+
+  getOutputPanel(): ITerminal | undefined {
+    return this._output;
+  }
+
+  hasTerminalPanel() {
+    return this.terminalConfig.get().panels.length > 0;
+  }
+
+  setTerminalConfiguration(config?: TerminalSchema) {
+    const oldTerminalConfig = this.terminalConfig.get();
+    const newTerminalConfig = new TerminalConfig(config);
+
+    // iterate over the old terminal config and make a list of all terminal panels
+    const panelMap = new Map<string, TerminalPanel>(oldTerminalConfig.panels.map((panel) => [panel.id, panel]));
+
+    // iterate over the new terminal panels and try to re-use the old terminal with the new panel
+    for (const panel of newTerminalConfig.panels) {
+      const oldPanel = panelMap.get(panel.id);
+
+      panelMap.delete(panel.id);
+
+      if (oldPanel?.terminal) {
+        // if we found a previous panel with the same id, attach that terminal to the new panel
+        panel.attachTerminal(oldPanel.terminal);
+      }
+
+      if (panel.type === 'output') {
+        this._output = panel;
+      }
+
+      if (panel.type === 'terminal' && !oldPanel) {
+        // if the panel is a terminal panel, and this panel didn't exist before, spawn a new JSH process
+        this._bootWebContainer(panel)
+          .then(async (webcontainerInstance) => {
+            panel.attachProcess(await newJSHProcess(webcontainerInstance, panel));
+          })
+          .catch(() => {
+            // do nothing
+          });
+      }
+    }
+
+    // kill all old processes which we couldn't re-use
+    for (const panel of panelMap.values()) {
+      panel.process?.kill();
+    }
+
+    this.terminalConfig.set(newTerminalConfig);
+  }
+
+  /**
+   * Attaches the provided terminal with the panel matching the provided ID.
+   *
+   * @param id The ID of the panel to attach the terminal with.
+   * @param terminal The terminal to hook up to the JSH process.
+   */
+  async attachTerminal(id: string, terminal: ITerminal) {
+    const panel = this.terminalConfig.get().panels.find((panel) => panel.id === id);
+
+    if (!panel) {
+      // if we don't have a panel with the provided id, just exit.
+      return;
+    }
+
+    panel.attachTerminal(terminal);
+  }
+
+  onTerminalResize(cols: number, rows: number) {
+    // iterate over all terminal panels and resize all processes
+    for (const panel of this.terminalConfig.get().panels) {
+      panel.process?.resize({ cols, rows });
+    }
+  }
+
+  private async _bootWebContainer(terminal: ITerminal) {
+    validateWebContainerSupported(terminal);
+
+    const isLoaded = this._webcontainerLoaded;
+
+    if (this._useAuth && !isLoaded) {
+      terminal.write('Waiting for authentication to complete...');
+
+      await auth.loggedIn();
+
+      clearTerminal(terminal);
+    }
+
+    if (!isLoaded) {
+      terminal.write('Booting WebContainer...');
+    }
+
+    try {
+      const webcontainerInstance = await this._webcontainer;
+
+      if (!isLoaded) {
+        clearTerminal(terminal);
+      }
+
+      return webcontainerInstance;
+    } catch (error) {
+      clearTerminal(terminal);
+
+      await tick();
+
+      terminal.write(
+        [
+          escapeCodes.red(`Looks like your browser's configuration is blocking WebContainers.`),
+          '',
+          `Let's troubleshoot this!`,
+          '',
+          'Read more at:',
+          'https://webcontainers.io/guides/browser-config',
+          '',
+        ].join('\n'),
+      );
+
+      throw error;
+    }
+  }
+}
+
+function validateWebContainerSupported(terminal: ITerminal) {
+  if (!isWebContainerSupported()) {
+    terminal.write(
+      [
+        escapeCodes.red('Incompatible Web Browser'),
+        '',
+        `WebContainers currently work in Chromium-based browsers, Firefox, and Safari 16.4. We're hoping to add support for more browsers as they implement the necessary Web Platform features.`,
+        '',
+        'Read more about browser support:',
+        'https://webcontainers.io/guides/browser-support',
+        '',
+      ].join('\n'),
+    );
+
+    throw new Error('Incompatible Web Browser');
+  }
+}

--- a/packages/runtime/src/utils/support.ts
+++ b/packages/runtime/src/utils/support.ts
@@ -1,24 +1,24 @@
 export function isWebContainerSupported() {
-  const hasSharedArrayBuffer = 'SharedArrayBuffer' in window;
-  const looksLikeChrome = navigator.userAgent.includes('Chrome');
-  const looksLikeFirefox = navigator.userAgent.includes('Firefox');
-  const looksLikeSafari = navigator.userAgent.includes('Safari');
-
-  if (hasSharedArrayBuffer && (looksLikeChrome || looksLikeFirefox)) {
-    return true;
-  }
-
-  if (hasSharedArrayBuffer && looksLikeSafari) {
-    // we only support Safari 16.4 and up so we check for the version here
-    const match = navigator.userAgent.match(/Version\/(\d+)\.(\d+) (?:Mobile\/.*?)?Safari/);
-    const majorVersion = match ? Number(match?.[1]) : 0;
-    const minorVersion = match ? Number(match?.[2]) : 0;
-
-    return majorVersion > 16 || (majorVersion === 16 && minorVersion >= 4);
-  }
-
-  // Allow overriding the support check with localStorage.webcontainer_any_ua = 1
   try {
+    const hasSharedArrayBuffer = 'SharedArrayBuffer' in globalThis;
+    const looksLikeChrome = navigator.userAgent.includes('Chrome');
+    const looksLikeFirefox = navigator.userAgent.includes('Firefox');
+    const looksLikeSafari = navigator.userAgent.includes('Safari');
+
+    if (hasSharedArrayBuffer && (looksLikeChrome || looksLikeFirefox)) {
+      return true;
+    }
+
+    if (hasSharedArrayBuffer && looksLikeSafari) {
+      // we only support Safari 16.4 and up so we check for the version here
+      const match = navigator.userAgent.match(/Version\/(\d+)\.(\d+) (?:Mobile\/.*?)?Safari/);
+      const majorVersion = match ? Number(match?.[1]) : 0;
+      const minorVersion = match ? Number(match?.[2]) : 0;
+
+      return majorVersion > 16 || (majorVersion === 16 && minorVersion >= 4);
+    }
+
+    // Allow overriding the support check with localStorage.webcontainer_any_ua = 1
     return Boolean(localStorage.getItem('webcontainer_any_ua'));
   } catch {
     return false;

--- a/packages/runtime/src/utils/terminal.ts
+++ b/packages/runtime/src/utils/terminal.ts
@@ -17,3 +17,8 @@ export const escapeCodes = {
   green: (text: string) => `\x1b[1;32m${text}${reset}`,
   magenta: (text: string) => `\x1b[35m${text}${reset}`,
 };
+
+export function clearTerminal(terminal?: ITerminal) {
+  terminal?.reset();
+  terminal?.write(escapeCodes.clear);
+}

--- a/packages/runtime/src/webcontainer/shell.ts
+++ b/packages/runtime/src/webcontainer/shell.ts
@@ -1,6 +1,6 @@
 import type { WebContainer } from '@webcontainer/api';
 import { withResolvers } from '../utils/promises.js';
-import type { ITerminal } from '../terminal.js';
+import type { ITerminal } from '../utils/terminal.js';
 
 export async function newJSHProcess(webcontainer: WebContainer, terminal: ITerminal) {
   // we spawn a JSH process with a fallback cols and rows in case the process is not attached yet to a visible terminal

--- a/packages/runtime/src/webcontainer/terminal-config.ts
+++ b/packages/runtime/src/webcontainer/terminal-config.ts
@@ -1,6 +1,6 @@
 import type { TerminalPanelType, TerminalSchema } from '@tutorialkit/types';
 import type { WebContainerProcess } from '@webcontainer/api';
-import type { ITerminal } from '../terminal.js';
+import type { ITerminal } from '../utils/terminal.js';
 
 type NormalizedTerminalConfig = {
   panels: TerminalPanel[];

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -5,5 +5,6 @@
     "rootDir": "src",
     "composite": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [{ "path": "../types" }]
 }

--- a/packages/types/src/entities/index.ts
+++ b/packages/types/src/entities/index.ts
@@ -4,7 +4,11 @@ export type * from './nav.js';
 
 export type Files = Record<string, string | Uint8Array>;
 
-export type FilesRef = [folder: string, files: string[]];
+/**
+ * This tuple contains a "ref" which points to a file to fetch with the `LessonFilesFetcher` and
+ * the list of file paths included by that ref.
+ */
+export type FilesRef = [ref: string, files: string[]];
 
 export interface LessonLink {
   href: string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,2 +1,2 @@
-export type * from './entities';
+export type * from './entities/index.js';
 export * from './schemas/index.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
+    "module": "nodenext",
     "verbatimModuleSyntax": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "nodenext",
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This PR refactors the logic that lived in `WorkspacePanel` to be in `@tutorialkit/runtime`. The idea behind this move is to support:
* Custom components that import a virtual module like `tutorialkit:state` to access the `tutorialStore`. This would then let them watch some state or modify it such as: run a command in a terminal, navigate a preview to a path, etc...
* Support components written for a different framework like svelte, etc...