### PR TITLE
feat: add lezer support for wast via codemirror wast package

### DIFF
--- a/.changeset/angry-man-yells.md
+++ b/.changeset/angry-man-yells.md
@@ -1,0 +1,5 @@
+---
+"@tutorialkit/astro": patch
+---
+
+feat: add wasm language support for syntax highlighting

--- a/packages/components/react/package.json
+++ b/packages/components/react/package.json
@@ -26,6 +26,7 @@
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/lang-markdown": "^6.2.5",
     "@codemirror/lang-sass": "^6.0.2",
+    "@codemirror/lang-wast": "^6.0.2",
     "@codemirror/language": "^6.10.1",
     "@codemirror/state": "^6.4.1",
     "@codemirror/view": "^6.26.3",

--- a/packages/components/react/src/CodeMirrorEditor/languages.ts
+++ b/packages/components/react/src/CodeMirrorEditor/languages.ts
@@ -71,6 +71,13 @@ export const supportedLanguages = [
       return import('@codemirror/lang-markdown').then((module) => module.markdown());
     },
   }),
+  LanguageDescription.of({
+    name: 'Wasm',
+    extensions: ['wat'],
+    async load() {
+      return import('@codemirror/lang-wast').then((module) => module.wast());
+    },
+  }),
 ];
 
 export async function getLanguage(fileName: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       '@codemirror/lang-sass':
         specifier: ^6.0.2
         version: 6.0.2(@codemirror/view@6.26.3)
+      '@codemirror/lang-wast':
+        specifier: ^6.0.2
+        version: 6.0.2
       '@codemirror/language':
         specifier: ^6.10.1
         version: 6.10.1
@@ -1143,6 +1146,15 @@ packages:
       '@lezer/sass': 1.0.6
     transitivePeerDependencies:
       - '@codemirror/view'
+    dev: false
+
+  /@codemirror/lang-wast@6.0.2:
+    resolution: {integrity: sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==}
+    dependencies:
+      '@codemirror/language': 6.10.1
+      '@lezer/common': 1.2.1
+      '@lezer/highlight': 1.2.0
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@codemirror/language@6.10.1:


### PR DESCRIPTION
Adds support for the wat language via [@codemirror/lang-wast](https://github.com/codemirror/lang-wast) ([context](https://x.com/elmd_/status/1800053726075310249))

We may want to explore exposing support for users to add their own lezer grammars and language servers. In the case of, perhaps a custom language, we might not want to merge it into the package directly but still want to allow support without monkey-patching the package.