### PR TITLE
chore: add packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "clean": "./scripts/clean.sh"
   },
   "license": "MIT",
+  "packageManager": "pnpm@8.10.5",
   "devDependencies": {
     "@commitlint/config-conventional": "^19.2.2",
     "commitlint": "^19.3.0",


### PR DESCRIPTION
We set the `packageManager` field so you can use `corepack` to make sure you are using the correct package manager version.