### PR TITLE
fix(nav): make sure nav is on top of the content

### DIFF
--- a/packages/components/react/src/Nav.tsx
+++ b/packages/components/react/src/Nav.tsx
@@ -40,7 +40,7 @@ export function Nav({ lesson: currentLesson, navList }: Props) {
           data-state={`${showDropdown ? 'open' : 'closed'}`}
           className={classNames(
             navStyles.NavContainer,
-            'absolute z-1 left-0 transition-[background,box-shadow] duration-0 right-0 rounded-[8px] border overflow-hidden',
+            'absolute z-1 left-0 transition-[background,box-shadow] duration-0 right-0 rounded-[8px] border overflow-hidden z-50',
           )}
           ref={menuRef}
         >


### PR DESCRIPTION
While using TutorialKit, I noticed that the navigation was not always on top of the content.

Before:
![image](https://github.com/stackblitz/tutorialkit/assets/1913805/894ae8b9-6697-49b0-af12-aef625044e1f)

After:
![image](https://github.com/stackblitz/tutorialkit/assets/1913805/99e7710a-b1bd-406b-8f63-aa245710d0f6)
