### PR TITLE
feat(store): fix current document and add onDocumentChanged

### DIFF
--- a/packages/components/react/src/Panels/EditorPanel.tsx
+++ b/packages/components/react/src/Panels/EditorPanel.tsx
@@ -1,5 +1,4 @@
-import type { Lesson } from '@tutorialkit/types';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle, type ImperativePanelHandle } from 'react-resizable-panels';
 import {
   CodeMirrorEditor,

--- a/packages/components/react/src/Terminal/index.tsx
+++ b/packages/components/react/src/Terminal/index.tsx
@@ -1,9 +1,13 @@
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
-import { Terminal as XTerm, type ITheme } from '@xterm/xterm';
+import { Terminal as XTerm } from '@xterm/xterm';
 import '@xterm/xterm/css/xterm.css';
-import { useEffect, useRef } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import { getTerminalTheme } from './theme.js';
+
+export interface TerminalRef {
+  reloadStyles: () => void;
+}
 
 export interface Props {
   theme: 'dark' | 'light';
@@ -13,66 +17,69 @@ export interface Props {
   onTerminalResize?: (cols: number, rows: number) => void;
 }
 
-export function Terminal({ theme, className, readonly = true, onTerminalReady, onTerminalResize }: Props) {
-  const divRef = useRef<HTMLDivElement>(null);
-  const terminalRef = useRef<XTerm>();
+const Terminal = forwardRef<TerminalRef, Props>(
+  ({ theme, className, readonly = true, onTerminalReady, onTerminalResize }, ref) => {
+    const divRef = useRef<HTMLDivElement>(null);
+    const terminalRef = useRef<XTerm>();
 
-  useEffect(() => {
-    if (!divRef.current) {
-      console.error('Terminal reference undefined');
-      return;
-    }
+    useEffect(() => {
+      const element = divRef.current!;
 
-    const element = divRef.current;
+      const fitAddon = new FitAddon();
+      const webLinksAddon = new WebLinksAddon();
 
-    const fitAddon = new FitAddon();
-    const webLinksAddon = new WebLinksAddon();
+      const terminal = new XTerm({
+        cursorBlink: true,
+        convertEol: true,
+        disableStdin: readonly,
+        theme: getTerminalTheme(readonly ? { cursor: '#00000000' } : {}),
+        fontSize: 13,
+        fontFamily: 'Menlo, courier-new, courier, monospace',
+      });
 
-    const terminal = new XTerm({
-      cursorBlink: true,
-      convertEol: true,
-      disableStdin: readonly,
-      theme: getTerminalTheme(readonly ? { cursor: '#00000000' } : {}),
-      fontSize: 13,
-      fontFamily: 'Menlo, courier-new, courier, monospace',
-    });
+      terminalRef.current = terminal;
 
-    terminalRef.current = terminal;
+      terminal.loadAddon(fitAddon);
+      terminal.loadAddon(webLinksAddon);
+      terminal.open(element);
 
-    terminal.loadAddon(fitAddon);
-    terminal.loadAddon(webLinksAddon);
-    terminal.open(element);
-
-    fitAddon.fit();
-
-    const resizeObserver = new ResizeObserver(() => {
       fitAddon.fit();
-      onTerminalResize?.(terminal.cols, terminal.rows);
-    });
 
-    resizeObserver.observe(element);
+      const resizeObserver = new ResizeObserver(() => {
+        fitAddon.fit();
+        onTerminalResize?.(terminal.cols, terminal.rows);
+      });
 
-    onTerminalReady?.(terminal);
+      resizeObserver.observe(element);
 
-    return () => {
-      resizeObserver.disconnect();
-      terminal.dispose();
-    };
-  }, []);
+      onTerminalReady?.(terminal);
 
-  useEffect(() => {
-    if (!terminalRef.current) {
-      return;
-    }
+      return () => {
+        resizeObserver.disconnect();
+        terminal.dispose();
+      };
+    }, []);
 
-    const terminal = terminalRef.current;
+    useEffect(() => {
+      const terminal = terminalRef.current!;
 
-    // we render a transparent cursor in case the terminal is readonly
-    terminal.options.theme = getTerminalTheme(readonly ? { cursor: '#00000000' } : {});
-    terminal.options.disableStdin = readonly;
-  }, [theme, readonly]);
+      // we render a transparent cursor in case the terminal is readonly
+      terminal.options.theme = getTerminalTheme(readonly ? { cursor: '#00000000' } : {});
+      terminal.options.disableStdin = readonly;
+    }, [theme, readonly]);
 
-  return <div className={`h-full ${className}`} ref={divRef} />;
-}
+    useImperativeHandle(ref, () => {
+      return {
+        reloadStyles: () => {
+          const terminal = terminalRef.current!;
+
+          terminal.options.theme = getTerminalTheme(readonly ? { cursor: '#00000000' } : {});
+        },
+      };
+    }, []);
+
+    return <div className={`h-full ${className}`} ref={divRef} />;
+  },
+);
 
 export default Terminal;

--- a/packages/runtime/src/store/index.ts
+++ b/packages/runtime/src/store/index.ts
@@ -30,6 +30,7 @@ export class TutorialStore {
   private _lessonTask: Task<unknown> | undefined;
   private _lesson: Lesson | undefined;
   private _ref: number = 1;
+  private _themeRef = atom(1);
 
   private _lessonFiles: Files | undefined;
   private _lessonSolution: Files | undefined;
@@ -203,6 +204,10 @@ export class TutorialStore {
     return this._ref;
   }
 
+  get themeRef(): ReadableAtom<unknown> {
+    return this._themeRef;
+  }
+
   /**
    * Steps that the runner is or will be executing.
    */
@@ -317,5 +322,13 @@ export class TutorialStore {
       this._terminalStore.onTerminalResize(cols, rows);
       this._runner.onTerminalResize(cols, rows);
     }
+  }
+
+  onDocumentChanged(filePath: string, callback: (document: Readonly<EditorDocument>) => void) {
+    return this._editorStore.onDocumentChanged(filePath, callback);
+  }
+
+  refreshStyles() {
+    this._themeRef.set(this._themeRef.get() + 1);
   }
 }


### PR DESCRIPTION
This PR fixes an issue where `store.updateFile()` didn't reflect the new content in the editor.

It also adds a new method to the store called `onDocumentChanged()` which you can use to subscribe to changed to a document. This allows you to do clever things in a custom component like listening to the changes of a `css` file and dynamically injecting that into the page.