### PR TITLE
fix: editor ignoring changes

### DIFF
--- a/packages/components/react/src/CodeMirrorEditor/index.tsx
+++ b/packages/components/react/src/CodeMirrorEditor/index.tsx
@@ -173,7 +173,7 @@ export function CodeMirrorEditor({
     view.setState(state);
 
     setEditorDocument(view, theme, language, readOnly, autoFocusOnDocumentChange, doc as TextEditorDocument);
-  }, [doc]);
+  }, [doc?.value, doc?.filePath, doc?.loading]);
 
   return (
     <div className="h-full relative">


### PR DESCRIPTION
This PR fixes a bug reported by @SamVerschueren where the editor sometimes remove a changes that was just made.

It's caused by the debounce which delay when the document is updated. However, the document might also be updated in the meantime by something else: here the scroll.

When the scroll position changes, the `document` will be updated which then cause the `useEffect` hook which calls `setEditorDocument` to be called and it would then think that the document has changed given the editor state content and the document content are different. So it resets the cursor to the beginning which is incorrect. With this PR, we ignore external scroll position changes as they are expected to be entirely controlled by the editor.

Note that there still could be a bug if an external component was also editing the editor state as if you keep pressing the same key you essentially prevent the document from ever being updated.

Before:

[now.webm](https://github.com/stackblitz/tutorialkit/assets/4008156/6a4aa72b-9875-4a3b-8ad0-55214d4287ec)

After:

[after.webm](https://github.com/stackblitz/tutorialkit/assets/4008156/5e2b2b49-51c4-4ae7-8182-7ae915e7dd50)
