### PR TITLE
fix: problem with creating lessons without solution files

### DIFF
--- a/packages/runtime/src/store/index.ts
+++ b/packages/runtime/src/store/index.ts
@@ -260,7 +260,7 @@ export class TutorialStore {
   }
 
   hasSolution(): boolean {
-    return !!this._lesson && Object.keys(this._lesson.solution).length >= 1;
+    return !!this._lesson && Object.keys(this._lesson.solution[1]).length >= 1;
   }
 
   reset() {


### PR DESCRIPTION
fix for https://github.com/stackblitz/tutorialkit/issues/107 In the hasSolution function of TutorialStore, `this._lessons.solution` is an array with the structure [lessonName, [list of solution files]]. Instead of checking the length of the solution array. we have to check the length of the second index which is the list of solution files.