### PR TITLE
docs: add social links

### DIFF
--- a/docs/tutorialkit.dev/astro.config.ts
+++ b/docs/tutorialkit.dev/astro.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
     react(),
     starlight({
       title: 'Create interactive coding tutorials',
+      social: {
+        github: 'https://github.com/stackblitz/tutorialkit',
+        'x.com': 'https://x.com/stackblitz',
+        discord: 'https://discord.com/invite/stackblitz',
+      },
       components: {
         Head: './src/components/Layout/Head.astro',
       },


### PR DESCRIPTION
This will add the social links to the top of [tutorialkit.dev](https://tutorialkit.dev).

I also linked X and Discord. Do we want that, because it just links to StackBlitz instead of something TutorialKit specific? @sulco

![image](https://github.com/stackblitz/tutorialkit/assets/1913805/1703180c-5bab-41af-a63d-ddaecd3f69aa)
