### PR TITLE
fix: generate correct changelogs when doing a PR

### DIFF
--- a/scripts/changelog.mjs
+++ b/scripts/changelog.mjs
@@ -6,13 +6,7 @@ import { generateChangelog } from './changelog/generate.mjs';
 const PRESET = 'angular';
 
 /**
- * @typedef {{
- *  path: string;
- *  excluded?: true;
- *  sameAs?: string;
- * }} PackageConfiguration A package in the monorepo to generate changelog for.
- *
- * @type {PackageConfiguration[]}
+ * @type {import('./changelog/Package.mjs').PackageConfiguration[]}
  */
 const PACKAGES = [
   { path: './packages/astro' },

--- a/scripts/changelog/Package.mjs
+++ b/scripts/changelog/Package.mjs
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export class Package {
+  /**
+   * @param {PackageDefinition} pkg
+   */
+  constructor(pkg) {
+    const pkgPath = path.normalize(pkg.path);
+    const pkgJSON = JSON.parse(fs.readFileSync(path.join(pkgPath, 'package.json')));
+
+    this.excluded = pkg.excluded;
+    this.path = pkgPath;
+    this.pkgJSON = pkgJSON;
+    this.changelogPath = path.join(pkgPath, 'CHANGELOG.md');
+  }
+
+  write() {
+    fs.writeFileSync(path.join(this.path, 'package.json'), JSON.stringify(this.pkgJSON, undefined, 2) + '\n', 'utf-8');
+  }
+
+  get name() {
+    return this.pkgJSON.name;
+  }
+
+  set name(value) {
+    this.pkgJSON.name = value;
+  }
+
+  get version() {
+    return this.pkgJSON.version;
+  }
+
+  set version(value) {
+    this.pkgJSON.version = value;
+  }
+}

--- a/scripts/changelog/Package.mjs
+++ b/scripts/changelog/Package.mjs
@@ -1,9 +1,17 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+/**
+ * @typedef {{
+ *  path: string;
+ *  excluded?: true;
+ *  sameAs?: string;
+ * }} PackageConfiguration A package in the monorepo to generate changelog for.
+ */
+
 export class Package {
   /**
-   * @param {PackageDefinition} pkg
+   * @param {PackageConfiguration} pkg
    */
   constructor(pkg) {
     const pkgPath = path.normalize(pkg.path);

--- a/scripts/changelog/generate.mjs
+++ b/scripts/changelog/generate.mjs
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import addStream from 'add-stream';
+import chalk from 'chalk';
+import conventionalChangelog from 'conventional-changelog';
+import tempfile from 'tempfile';
+
+/**
+ * @typedef {{
+ *  path: string;
+ *  gitPath?: string;
+ *  version: string;
+ *  name: string;
+ *  changelogPath: string;
+ * }} PackageSpec A package specification to generate the changelog from.
+ */
+
+/**
+ * Generate a changelog for the provided package and aggregate the data
+ * for the root changelog.
+ *
+ * @param {PackageSpec} pkg the package
+ * @param {string} preset preset to use
+ */
+export function generateChangelog(pkg, preset) {
+  const options = {
+    preset,
+    pkg: {
+      path: pkg.path,
+    },
+    append: undefined,
+    releaseCount: undefined,
+    skipUnstable: undefined,
+    outputUnreleased: undefined,
+    tagPrefix: undefined,
+  };
+
+  const context = {
+    version: pkg.version,
+    title: pkg.name,
+  };
+
+  const gitRawCommitsOpts = {
+    path: pkg.gitPath ?? pkg.path,
+  };
+
+  const changelogStream = conventionalChangelog(options, context, gitRawCommitsOpts).on('error', (error) => {
+    console.error(error.stack);
+    process.exit(1);
+  });
+
+  const CHANGELOG_FILE = pkg.changelogPath;
+
+  return new Promise((resolve) => {
+    const readStream = fs.createReadStream(CHANGELOG_FILE).on('error', () => {
+      // if there was no changelog we create it here
+      changelogStream.pipe(fs.createWriteStream(CHANGELOG_FILE)).on('finish', resolve);
+    });
+
+    const tmp = tempfile();
+
+    changelogStream
+      .pipe(addStream(readStream))
+      .pipe(fs.createWriteStream(tmp))
+      .on('finish', () => {
+        fs.createReadStream(tmp).pipe(fs.createWriteStream(CHANGELOG_FILE)).on('finish', resolve);
+      });
+  }).then(() => {
+    console.log(`${chalk.green('UPDATED')} ${CHANGELOG_FILE} ${chalk.gray(pkg.version)}`);
+  });
+}


### PR DESCRIPTION
This PR fix the changelog generation so that it when we do `pnpm changelog` it generate the changelog for every packages, in particular the CLI. The previous release PR didn't had the changelog for the CLI because we are bumping the CLI at a later point.