### PR TITLE
ci(publish): fix publish config

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -14,6 +14,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -30,7 +30,7 @@ jobs:
         run: >
           pnpm --recursive
           --filter "@tutorialkit/*"
-          exec pnpm publish --provenance
+          exec pnpm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -103,6 +103,6 @@ jobs:
           pnpm --recursive
           --filter tutorialkit
           --filter create-tutorial
-          exec pnpm publish --provenance
+          exec pnpm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -7,6 +7,11 @@
   "bugs": "https://github.com/stackblitz/tutorialkit/issues",
   "homepage": "https://github.com/stackblitz/tutorialkit",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stackblitz/tutorialkit.git",
+    "directory": "packages/astro"
+  },
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,6 +7,11 @@
   "bugs": "https://github.com/stackblitz/tutorialkit/issues",
   "homepage": "https://github.com/stackblitz/tutorialkit",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stackblitz/tutorialkit.git",
+    "directory": "packages/cli"
+  },
   "bin": {
     "tutorialkit": "dist/index.js"
   },

--- a/packages/components/react/package.json
+++ b/packages/components/react/package.json
@@ -7,6 +7,11 @@
   "bugs": "https://github.com/stackblitz/tutorialkit/issues",
   "homepage": "https://github.com/stackblitz/tutorialkit",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stackblitz/tutorialkit.git",
+    "directory": "packages/components/react"
+  },
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/packages/create-tutorial/package.json
+++ b/packages/create-tutorial/package.json
@@ -7,6 +7,11 @@
   "bugs": "https://github.com/stackblitz/tutorialkit/issues",
   "homepage": "https://github.com/stackblitz/tutorialkit",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stackblitz/tutorialkit.git",
+    "directory": "packages/create-tutorial"
+  },
   "bin": {
     "create-tutorial": "./dist/index.js"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -7,6 +7,11 @@
   "bugs": "https://github.com/stackblitz/tutorialkit/issues",
   "homepage": "https://github.com/stackblitz/tutorialkit",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stackblitz/tutorialkit.git",
+    "directory": "packages/runtime"
+  },
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -7,6 +7,11 @@
   "bugs": "https://github.com/stackblitz/tutorialkit/issues",
   "homepage": "https://github.com/stackblitz/tutorialkit",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stackblitz/tutorialkit.git",
+    "directory": "packages/theme"
+  },
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,6 +7,11 @@
   "bugs": "https://github.com/stackblitz/tutorialkit/issues",
   "homepage": "https://github.com/stackblitz/tutorialkit",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stackblitz/tutorialkit.git",
+    "directory": "packages/types"
+  },
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js"


### PR DESCRIPTION
- Scoped packages require `--access public`. It's designed to prevent accidentally publishing scoped packages to public. We do it intentionally for `@tutorialkit/*` packages.
- Github Actions instruct to set `registry` explicitly, though I'm not sure if this is required. 
  - > Please note that you need to set the `registry-url` to `https://registry.npmjs.org/` in `setup-node` to properly configure your credentials.
    > https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
- `--provenance` flag requires `repository` in `package.json`

Example run which published couple of packages:
- https://github.com/stackblitz/tutorialkit/actions/runs/9854149942/job/27206280839
- https://www.npmjs.com/package/@tutorialkit/runtime

⚠️ Once this is merged, we should immediately publish next `0.0.1-alpha.25`. It's fine to skip `24` for the other packages. 
