### PR TITLE
fix: tag should be the version without the 'v'

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -38,8 +38,8 @@ jobs:
         run: |
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@users.noreply.github.com'
-          git tag v${{ steps.resolve-release-version.outputs.version }}
-          git push origin v${{ steps.resolve-release-version.outputs.version }}
+          git tag ${{ steps.resolve-release-version.outputs.version }}
+          git push origin ${{ steps.resolve-release-version.outputs.version }}
 
   prepare_cli_release:
     name: Prepare Release for CLI


### PR DESCRIPTION
This PR update the tag updated by the CI to make sure they don't include the `v` prefix. Otherwise this break the changelog generation.