### PR TITLE
fix(ci): use PAT to make sure release PRs trigger workflows

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -31,7 +31,7 @@ jobs:
         run: pnpm run changelog
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           # Note: `publish-release.yaml` checks explicitly for this commit message
           commit-message: 'chore: release `@tutorialkit` packages v${{ inputs.version }}'

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -39,3 +39,4 @@ jobs:
           body: 'Bump `@tutorialkit` packages to version ${{ inputs.version }} and generate changelogs.'
           reviewers: SamVerschueren,d3lm,Nemikolh,AriPerkkio
           branch: chore/release-${{ inputs.version }}
+          token: ${{ secrets.GITOPS_REPO_PAT }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -73,6 +73,7 @@ jobs:
           body: 'Bump TutorialKit CLI to version ${{ steps.resolve-release-version.outputs.version }}.'
           reviewers: SamVerschueren,d3lm,Nemikolh,AriPerkkio
           branch: chore/release-cli-${{ steps.resolve-release-version.outputs.version }}
+          token: ${{ secrets.GITOPS_REPO_PAT }}
 
   publish_release_CLI:
     name: Publish Release CLI

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -65,7 +65,7 @@ jobs:
           exec npm version --no-git-tag-version --allow-same-version ${{ steps.resolve-release-version.outputs.version }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           # Note: `publish-release.yaml` checks explicitly for this commit message
           commit-message: 'chore: release TutorialKit CLI v${{ steps.resolve-release-version.outputs.version }}'


### PR DESCRIPTION
This PR replace the default use of the `GITHUB_TOKEN` with `GITOPS_REPO_PAT` which means that release PRs should now properly trigger workflows.