### PR TITLE
build(cli): disable minifying

### DIFF
--- a/packages/cli/scripts/build.js
+++ b/packages/cli/scripts/build.js
@@ -8,7 +8,7 @@ fs.rmSync(distFolder, { recursive: true, force: true });
 
 esbuild.build({
   entryPoints: ['src/index.ts'],
-  minify: true,
+  minify: false,
   bundle: true,
   platform: 'node',
   target: 'node18',


### PR DESCRIPTION
- Disables minifying `tutorialkit` CLI package.

For transparency let's not minify the published CLI package. Seeing code like https://unpkg.com/browse/tutorialkit@0.0.1-alpha.25/dist/index.js doesn't make me eager to run it on my machine. Nowadays it's quite common practice to not minify code that's not going to CDN.


