### PR TITLE
ci: remove PAT usage

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -39,4 +39,3 @@ jobs:
           body: 'Bump `@tutorialkit` packages to version ${{ inputs.version }} and generate changelogs.'
           reviewers: SamVerschueren,d3lm,Nemikolh,AriPerkkio
           branch: chore/release-${{ inputs.version }}
-          token: ${{ secrets.GITOPS_REPO_PAT }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -73,7 +73,6 @@ jobs:
           body: 'Bump TutorialKit CLI to version ${{ steps.resolve-release-version.outputs.version }}.'
           reviewers: SamVerschueren,d3lm,Nemikolh,AriPerkkio
           branch: chore/release-cli-${{ steps.resolve-release-version.outputs.version }}
-          token: ${{ secrets.GITOPS_REPO_PAT }}
 
   publish_release_CLI:
     name: Publish Release CLI


### PR DESCRIPTION
- Reverts https://github.com/stackblitz/tutorialkit/pull/124 as `secrets.GITOPS_REPO_PAT` is not yet available