### PR TITLE
fix: a transition-theme class was missing for the content right border

### DIFF
--- a/packages/astro/src/default/components/MainContainer.astro
+++ b/packages/astro/src/default/components/MainContainer.astro
@@ -34,7 +34,10 @@ const showWorkspacePanel = hasWorkspace(lesson);
     <Nav client:load lesson={lesson} navList={navList} />
     <TutorialContent lesson={lesson} />
   </div>
-  <div class="h-full sm:border-l border-tk-elements-app-borderColor" slot={showWorkspacePanel ? 'b' : 'hide'}>
+  <div
+    class="h-full sm:border-l transition-theme border-tk-elements-app-borderColor"
+    slot={showWorkspacePanel ? 'b' : 'hide'}
+  >
     <WorkspacePanel lesson={lesson} client:load transition:persist />
   </div>
 </ResizablePanel>


### PR DESCRIPTION
This PR adds a missing `transition-theme` class on the border. Thanks @d3lm for the find! :smiley: 