### PR TITLE
ci: separate `create-tutorial` releasing

### DIFF
--- a/.github/workflows/publish-create-tutorial.yaml
+++ b/.github/workflows/publish-create-tutorial.yaml
@@ -1,0 +1,66 @@
+name: Prepare create-tutorial Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish, e.g. 0.0.1'
+        required: true
+        default: '0.0.1'
+        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/create-tutorial/package.json'
+
+jobs:
+  prepare_release_create_tutorial:
+    name: Prepare Release PR
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-and-build
+
+      - name: Bump versions
+        run: >
+          pnpm --recursive
+          --filter "create-tutorial"
+          exec pnpm version --no-git-tag-version --allow-same-version ${{ inputs.version }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
+        with:
+          commit-message: 'chore: release `create-tutorial` v${{ inputs.version }}'
+          title: 'chore: release `create-tutorial` v${{ inputs.version }}'
+          body: 'Bump `create-tutorial` to version ${{ inputs.version }}.'
+          reviewers: SamVerschueren,d3lm,Nemikolh,AriPerkkio
+          branch: chore/release-create-tutorial-${{ inputs.version }}
+
+  publish_release_create_tutorial:
+    name: Publish Release create-tutorial
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    if: ${{ contains(github.event.head_commit.message, 'release `create-tutorial`') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-and-build
+
+      - name: Publish to npm
+        run: >
+          pnpm --recursive
+          --filter create-tutorial
+          exec pnpm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -61,7 +61,6 @@ jobs:
         run: >
           pnpm --recursive
           --filter tutorialkit
-          --filter create-tutorial
           exec npm version --no-git-tag-version --allow-same-version ${{ steps.resolve-release-version.outputs.version }}
 
       - name: Create Pull Request
@@ -102,7 +101,6 @@ jobs:
         run: >
           pnpm --recursive
           --filter tutorialkit
-          --filter create-tutorial
           exec pnpm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/create-tutorial/package.json
+++ b/packages/create-tutorial/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "dependencies": {
-    "tutorialkit": "workspace:*"
+    "tutorialkit": "latest"
   },
   "devDependencies": {
     "@types/node": "^20.14.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,7 +458,7 @@ importers:
   packages/create-tutorial:
     dependencies:
       tutorialkit:
-        specifier: workspace:*
+        specifier: latest
         version: link:../cli
     devDependencies:
       '@types/node':


### PR DESCRIPTION
Separates `create-tutorial` package releasing from all other `@tutorialkit/*` and `tutorialkit` packages. The `create-tutorial` is essentially only an alias for installing `tutorialkit` package and calling it. I don't think we'll be publishing many versions of this package. 

- Added workflow for separately specifying version for `create-tutorial` and publishing it
- Defined `create-tutorial` package's dependency on `tutorialkit` as `latest`, so that package managers will always install the latest version of it.

Example:
- Manually run the preparation PR workflow: https://github.com/AriPerkkio/tutorialkit/actions/runs/9973462056
- PR is created: https://github.com/AriPerkkio/tutorialkit/pull/36
- Once PR is merged, publish starts automatically: https://github.com/AriPerkkio/tutorialkit/actions/runs/9973515249
