### PR TITLE
feat!: rename `tutorialkit` to `@tutorialkit/cli`

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -24,6 +24,7 @@ jobs:
       - name: Bump versions
         run: >
           pnpm --recursive
+          --filter "!@tutorialkit/cli"
           --filter "@tutorialkit/*"
           exec pnpm version --no-git-tag-version --allow-same-version ${{ inputs.version }}
 
@@ -34,9 +35,9 @@ jobs:
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           # Note: `publish-release.yaml` checks explicitly for this commit message
-          commit-message: 'chore: release `@tutorialkit` packages v${{ inputs.version }}'
-          title: 'chore: release `@tutorialkit` packages v${{ inputs.version }}'
-          body: 'Bump `@tutorialkit` packages to version ${{ inputs.version }} and generate changelogs.'
+          commit-message: 'chore: release core packages v${{ inputs.version }}'
+          title: 'chore: release core packages v${{ inputs.version }}'
+          body: 'Bump core packages to version ${{ inputs.version }} and generate changelogs.'
           reviewers: SamVerschueren,d3lm,Nemikolh,AriPerkkio
           branch: chore/release-${{ inputs.version }}
           token: ${{ secrets.GITOPS_REPO_PAT }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: write
       id-token: write
     # Note: `prepare-release.yaml` sets this commit message
-    if: ${{ contains(github.event.head_commit.message, 'release `@tutorialkit` packages') }}
+    if: ${{ contains(github.event.head_commit.message, 'release core packages') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,6 +29,7 @@ jobs:
       - name: Publish to npm
         run: >
           pnpm --recursive
+          --filter "!@tutorialkit/cli"
           --filter "@tutorialkit/*"
           exec pnpm publish --provenance --access public
         env:
@@ -60,16 +61,16 @@ jobs:
       - name: Bump version
         run: >
           pnpm --recursive
-          --filter tutorialkit
+          --filter @tutorialkit/cli
           exec npm version --no-git-tag-version --allow-same-version ${{ steps.resolve-release-version.outputs.version }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           # Note: `publish-release.yaml` checks explicitly for this commit message
-          commit-message: 'chore: release TutorialKit CLI v${{ steps.resolve-release-version.outputs.version }}'
-          title: 'chore: release TutorialKit CLI v${{ steps.resolve-release-version.outputs.version }}'
-          body: 'Bump TutorialKit CLI to version ${{ steps.resolve-release-version.outputs.version }}.'
+          commit-message: 'chore: release CLI v${{ steps.resolve-release-version.outputs.version }}'
+          title: 'chore: release CLI v${{ steps.resolve-release-version.outputs.version }}'
+          body: 'Bump CLI to version ${{ steps.resolve-release-version.outputs.version }}.'
           reviewers: SamVerschueren,d3lm,Nemikolh,AriPerkkio
           branch: chore/release-cli-${{ steps.resolve-release-version.outputs.version }}
           token: ${{ secrets.GITOPS_REPO_PAT }}
@@ -80,8 +81,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    # Note: `prepare-release.yaml` sets this commit message
-    if: ${{ contains(github.event.head_commit.message, 'release TutorialKit CLI') }}
+    # Note: commit message is set by prepare_cli_release above
+    if: ${{ contains(github.event.head_commit.message, 'release CLI') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -101,7 +102,7 @@ jobs:
       - name: Publish to npm
         run: >
           pnpm --recursive
-          --filter tutorialkit
+          --filter @tutorialkit/cli
           exec pnpm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ These packages will be installed by the end-users in their `package.json`.
 ### CLI Packages
 
 The CLI packages are expected to be run by users using `npm create tutorial` and `npx tutorialkit` commands.
-These should not be installed in their `package.json`.
+These should not be added to `package.json`.
 
 - `@tutorialkit/cli`
 - `create-tutorial`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,26 @@ cd tutorialkit
 
 5. Run `pnpm run test` to run core tests
 
+The monorepo consists of multiple packages that are grouped into following groups:
+
+### Core Packages
+
+These packages will be installed by the end-users in their `package.json`.
+
+- `@tutorialkit/astro`
+- `@tutorialkit/components-react`
+- `@tutorialkit/runtime`
+- `@tutorialkit/theme`
+- `@tutorialkit/types`
+
+### CLI Packages
+
+The CLI packages are expected to be run by users using `npm create tutorial` and `npx tutorialkit` commands.
+These should not be installed in their `package.json`.
+
+- `@tutorialkit/cli`
+- `create-tutorial`
+
 ## Testing TutorialKit against external packages
 
 You may wish to test your locally-modified copy of TutorialKit against another package that is using it. For pnpm, after building TutorialKit, you can use [`pnpm.overrides`](https://pnpm.io/package_json#pnpmoverrides). Please note that `pnpm.overrides` must be specified in the root `package.json` and you must first list the package as a dependency in the root `package.json`:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Read our documentation on [tutorialkit.dev](https://tutorialkit.dev/guides/about
 
 ### Contribution
 
-See [Contributing Guide](https://github.com/stackblitz/tutorialkit/blob/main/CONTRIBUTING.md).
+See [Contributing Guide](./CONTRIBUTING.md).
 
 ## Community
 

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tutorialkit-vscode",
+  "name": "tutorialkit",
   "displayName": "TutorialKit",
   "description": "TutorialKit support in VS Code",
   "icon": "resources/tutorialkit-icon.png",

--- a/extensions/vscode/scripts/build.mjs
+++ b/extensions/vscode/scripts/build.mjs
@@ -55,15 +55,6 @@ async function main() {
     await ctx.dispose();
 
     await buildMetadataSchema();
-
-    if (production) {
-      // rename name in `package.json` to match extension name on store
-      const pkgJSON = JSON.parse(fs.readFileSync('./package.json', { encoding: 'utf8' }));
-
-      pkgJSON.name = 'tutorialkit';
-
-      fs.writeFileSync('./package.json', JSON.stringify(pkgJSON, undefined, 2), 'utf8');
-    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "pnpm run --filter=@tutorialkit/* --filter=tutorialkit --filter=create-tutorial build",
+    "build": "pnpm run --stream  --filter=@tutorialkit/* --filter=create-tutorial build",
     "dev": "TUTORIALKIT_DEV=true pnpm -r --parallel --stream --filter='./packages/**' run dev",
     "changelog": "./scripts/changelog.mjs",
     "clean": "./scripts/clean.sh",
@@ -10,13 +10,13 @@
     "extension:build": "pnpm run --filter=tutorialkit-vscode build",
     "template:dev": "TUTORIALKIT_DEV=true pnpm run build && pnpm run --filter=tutorialkit-starter dev",
     "template:build": "pnpm run build && pnpm run --filter=tutorialkit-starter build",
-    "cli:build-release": "pnpm run --filter=tutorialkit build-release",
+    "cli:build-release": "pnpm run --filter=@tutorialkit/cli build-release",
     "docs": "pnpm run --filter=tutorialkit.dev dev",
     "docs:build": "pnpm run build && pnpm run --filter=tutorialkit.dev build",
     "demo": "pnpm run --filter=demo.tutorialkit.dev dev",
     "demo:build": "pnpm run build && pnpm run --filter=demo.tutorialkit.dev build",
     "lint": "eslint \"{packages,docs,extensions,integration}/**/*\"",
-    "test": "pnpm run --stream --filter=@tutorialkit/* --filter=tutorialkit test --run"
+    "test": "pnpm run --stream --filter=@tutorialkit/* test --run"
   },
   "license": "MIT",
   "packageManager": "pnpm@8.15.6",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "scripts": {
-    "build": "pnpm run --stream  --filter=@tutorialkit/* --filter=create-tutorial build",
+    "build": "pnpm run --stream --filter=@tutorialkit/* --filter=create-tutorial build",
     "dev": "TUTORIALKIT_DEV=true pnpm -r --parallel --stream --filter='./packages/**' run dev",
     "changelog": "./scripts/changelog.mjs",
     "clean": "./scripts/clean.sh",
     "prepare": "is-ci || husky install",
-    "extension:dev": "pnpm --parallel --stream --filter=@tutorialkit/types --filter=tutorialkit-vscode run dev",
-    "extension:build": "pnpm run --filter=tutorialkit-vscode build",
+    "extension:dev": "pnpm run --parallel --stream --filter=@tutorialkit/types --filter='./extensions/**' dev",
+    "extension:build": "pnpm run --filter='./extensions/**' build",
     "template:dev": "TUTORIALKIT_DEV=true pnpm run build && pnpm run --filter=tutorialkit-starter dev",
     "template:build": "pnpm run build && pnpm run --filter=tutorialkit-starter build",
     "cli:build-release": "pnpm run --filter=@tutorialkit/cli build-release",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tutorialkit",
+  "name": "@tutorialkit/cli",
   "version": "0.1.2",
   "description": "Interactive tutorials powered by WebContainer API",
   "author": "StackBlitz Inc.",

--- a/packages/create-tutorial/package.json
+++ b/packages/create-tutorial/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "dependencies": {
-    "tutorialkit": "latest"
+    "@tutorialkit/cli": "latest"
   },
   "devDependencies": {
     "@types/node": "^20.14.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,7 +530,7 @@ importers:
 
   packages/create-tutorial:
     dependencies:
-      tutorialkit:
+      '@tutorialkit/cli':
         specifier: latest
         version: link:../cli
     devDependencies:

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# if no tag is specified we'll use 'latest' as the default
-TAG=${1:-latest}
-
-pnpm build && pnpm publish --recursive --tag "$TAG" --filter "@tutorialkit/*" --filter "tutorialkit" --filter "create-tutorial" "$@"


### PR DESCRIPTION
- Renames npm package `tutorialkit` to `@tutorialkit/cli`
- Adds some documentation to `CONTRIBUTING.md` about package naming convention. This is mostly related to development time communication practices and doesn't affect end users.
- Renames (internally) `tutorialkit-vscode` to `tutorialkit`. Removes work-around from build script that was used to do this renaming right before publishing. This name is already used by the published extension. 

BREAKING CHANGES:
- `tutorialkit` npm package is now unused. We should probably deprecate that from npm? Or just leave it as is. 
- Adds new package `@tutorialkit/cli`. This package does not yet exist in npm. I'm not sure if publishing this package will work without any permission settings. Do we need to add https://www.npmjs.com/~stackblitz-devops there some how?