### PR TITLE
ci: use PAT on `create-pull-request`

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -39,3 +39,4 @@ jobs:
           body: 'Bump `@tutorialkit` packages to version ${{ inputs.version }} and generate changelogs.'
           reviewers: SamVerschueren,d3lm,Nemikolh,AriPerkkio
           branch: chore/release-${{ inputs.version }}
+          token: ${{ secrets.GITOPS_REPO_PAT }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -72,6 +72,7 @@ jobs:
           body: 'Bump TutorialKit CLI to version ${{ steps.resolve-release-version.outputs.version }}.'
           reviewers: SamVerschueren,d3lm,Nemikolh,AriPerkkio
           branch: chore/release-cli-${{ steps.resolve-release-version.outputs.version }}
+          token: ${{ secrets.GITOPS_REPO_PAT }}
 
   publish_release_CLI:
     name: Publish Release CLI


### PR DESCRIPTION
- Adds `token` to `create-pull-request` workflow so that CI workflows start automatically when bot creates the PR
- Tested here https://github.com/stackblitz/tutorialkit/pull/160
