### PR TITLE
chore: release `@tutorialkit` packages v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) (2024-07-23)
+
+
+### Bug Fixes
+
+* **deps:** update `astro` for Node 18.18 compatibility ([#159](https://github.com/stackblitz/tutorialkit/issues/159)) ([4b50335](https://github.com/stackblitz/tutorialkit/commit/4b50335d284fd22d38d9dab2c0f85e219533a9e5))
+
+
+
 ## [0.0.2](https://github.com/stackblitz/tutorialkit/compare/0.0.1...0.0.2) (2024-07-17)
 
 

--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) "@tutorialkit/astro" (2024-07-23)
+
+
+### Bug Fixes
+
+* **deps:** update `astro` for Node 18.18 compatibility ([#159](https://github.com/stackblitz/tutorialkit/issues/159)) ([4b50335](https://github.com/stackblitz/tutorialkit/commit/4b50335d284fd22d38d9dab2c0f85e219533a9e5))
+
+
+
 ## [0.0.2](https://github.com/stackblitz/tutorialkit/compare/0.0.1...0.0.2) "@tutorialkit/astro" (2024-07-17)
 
 

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/astro",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "TutorialKit integration for Astro (https://astro.build)",
   "author": "StackBlitz Inc.",
   "type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) "tutorialkit" (2024-07-23)
+
+
+
 ## [0.0.2](https://github.com/stackblitz/tutorialkit/compare/0.0.1...0.0.2) "tutorialkit" (2024-07-17)
 
 

--- a/packages/components/react/CHANGELOG.md
+++ b/packages/components/react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) "@tutorialkit/components-react" (2024-07-23)
+
+
+
 ## [0.0.2](https://github.com/stackblitz/tutorialkit/compare/0.0.1...0.0.2) "@tutorialkit/components-react" (2024-07-17)
 
 

--- a/packages/components/react/package.json
+++ b/packages/components/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/components-react",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "TutorialKit's React components",
   "author": "StackBlitz Inc.",
   "type": "module",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) "@tutorialkit/runtime" (2024-07-23)
+
+
+
 ## [0.0.2](https://github.com/stackblitz/tutorialkit/compare/0.0.1...0.0.2) "@tutorialkit/runtime" (2024-07-17)
 
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/runtime",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "TutorialKit runtime",
   "author": "StackBlitz Inc.",
   "type": "module",

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) "@tutorialkit/theme" (2024-07-23)
+
+
+
 ## [0.0.2](https://github.com/stackblitz/tutorialkit/compare/0.0.1...0.0.2) "@tutorialkit/theme" (2024-07-17)
 
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/theme",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "TutorialKit theme configuration",
   "author": "StackBlitz Inc.",
   "type": "module",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) "@tutorialkit/types" (2024-07-23)
+
+
+
 ## [0.0.2](https://github.com/stackblitz/tutorialkit/compare/0.0.1...0.0.2) "@tutorialkit/types" (2024-07-17)
 
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/types",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Types for TutorialKit",
   "author": "StackBlitz Inc.",
   "type": "module",


### PR DESCRIPTION
Bump `@tutorialkit` packages to version 0.0.3 and generate changelogs.