### PR TITLE
chore: release `@tutorialkit` packages v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) (2024-07-25)
+
+
+### Bug Fixes
+
+* **cli:** remove vs code `settings.json` ([#173](https://github.com/stackblitz/tutorialkit/issues/173)) ([8dde2c3](https://github.com/stackblitz/tutorialkit/commit/8dde2c3248fe897921c1e928f5084c426270ede2))
+* **docs:** jumping to bottom of getting started page ([#170](https://github.com/stackblitz/tutorialkit/issues/170)) ([55430f9](https://github.com/stackblitz/tutorialkit/commit/55430f9006427e9435e9ce7d1be62315c6575e2b))
+* solve shows lesson-only files empty ([#168](https://github.com/stackblitz/tutorialkit/issues/168)) ([bbb13f7](https://github.com/stackblitz/tutorialkit/commit/bbb13f7251a5259a3f7b4fc8300d0b308828bd73))
+
+
+### Features
+
+* add `contentSchema` ([#156](https://github.com/stackblitz/tutorialkit/issues/156)) ([bc0fde2](https://github.com/stackblitz/tutorialkit/commit/bc0fde26025465f5ab1fa71613d92293f0dafa89))
+* **cli:** add vs code extension to recommendations ([#172](https://github.com/stackblitz/tutorialkit/issues/172)) ([f6fd489](https://github.com/stackblitz/tutorialkit/commit/f6fd48986c4760447c11743174c3448b9b733c4f))
+* **extension:** metadata autocompletion ([#143](https://github.com/stackblitz/tutorialkit/issues/143)) ([be0a096](https://github.com/stackblitz/tutorialkit/commit/be0a0965bbd7b553bc6b5b1f4019e22ee0651d30))
+
+
+
 ## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) (2024-07-23)
 
 

--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) "@tutorialkit/astro" (2024-07-25)
+
+
+
 ## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) "@tutorialkit/astro" (2024-07-23)
 
 

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/astro",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "TutorialKit integration for Astro (https://astro.build)",
   "author": "StackBlitz Inc.",
   "type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) "tutorialkit" (2024-07-25)
+
+
+### Bug Fixes
+
+* **cli:** remove vs code `settings.json` ([#173](https://github.com/stackblitz/tutorialkit/issues/173)) ([8dde2c3](https://github.com/stackblitz/tutorialkit/commit/8dde2c3248fe897921c1e928f5084c426270ede2))
+* solve shows lesson-only files empty ([#168](https://github.com/stackblitz/tutorialkit/issues/168)) ([bbb13f7](https://github.com/stackblitz/tutorialkit/commit/bbb13f7251a5259a3f7b4fc8300d0b308828bd73))
+
+
+
 ## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) "tutorialkit" (2024-07-23)
 
 

--- a/packages/components/react/CHANGELOG.md
+++ b/packages/components/react/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) "@tutorialkit/components-react" (2024-07-25)
+
+
+
 ## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) "@tutorialkit/components-react" (2024-07-23)
 
 

--- a/packages/components/react/package.json
+++ b/packages/components/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/components-react",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "TutorialKit's React components",
   "author": "StackBlitz Inc.",
   "type": "module",

--- a/packages/create-tutorial/CHANGELOG.md
+++ b/packages/create-tutorial/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.2](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.0.2) "create-tutorial" (2024-07-25)
+
+
+
 ## [0.0.1-alpha.26](https://github.com/stackblitz/tutorialkit/compare/0.0.1...0.0.1-alpha.26) "create-tutorial" (2024-07-17)
 
 

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) "@tutorialkit/runtime" (2024-07-25)
+
+
+### Bug Fixes
+
+* solve shows lesson-only files empty ([#168](https://github.com/stackblitz/tutorialkit/issues/168)) ([bbb13f7](https://github.com/stackblitz/tutorialkit/commit/bbb13f7251a5259a3f7b4fc8300d0b308828bd73))
+
+
+
 ## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) "@tutorialkit/runtime" (2024-07-23)
 
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/runtime",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "TutorialKit runtime",
   "author": "StackBlitz Inc.",
   "type": "module",

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) "@tutorialkit/theme" (2024-07-25)
+
+
+
 ## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) "@tutorialkit/theme" (2024-07-23)
 
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/theme",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "TutorialKit theme configuration",
   "author": "StackBlitz Inc.",
   "type": "module",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) "@tutorialkit/types" (2024-07-25)
+
+
+### Features
+
+* add `contentSchema` ([#156](https://github.com/stackblitz/tutorialkit/issues/156)) ([bc0fde2](https://github.com/stackblitz/tutorialkit/commit/bc0fde26025465f5ab1fa71613d92293f0dafa89))
+* **extension:** metadata autocompletion ([#143](https://github.com/stackblitz/tutorialkit/issues/143)) ([be0a096](https://github.com/stackblitz/tutorialkit/commit/be0a0965bbd7b553bc6b5b1f4019e22ee0651d30))
+
+
+
 ## [0.0.3](https://github.com/stackblitz/tutorialkit/compare/0.0.2...0.0.3) "@tutorialkit/types" (2024-07-23)
 
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/types",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Types for TutorialKit",
   "author": "StackBlitz Inc.",
   "type": "module",


### PR DESCRIPTION
Bump `@tutorialkit` packages to version 0.1.0 and generate changelogs.