### PR TITLE
chore: release TutorialKit vscode extension v0.1.0

### DIFF
--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "tutorialkit" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.1.0]
+
+- Add autocompletion in the metadata of TutorialKit markdown and mdx files (see: https://github.com/stackblitz/tutorialkit/pull/143)
+
 ## [0.0.11]
 
 - Remove the error toast appearing when loading the extension with no workspace present

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -4,7 +4,7 @@
   "description": "TutorialKit support in VS Code",
   "icon": "resources/tutorialkit-icon.png",
   "publisher": "StackBlitz",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "engines": {
     "vscode": "^1.80.0"
   },


### PR DESCRIPTION
We want to release the extension update that includes the frontmatter autocompletion. 