### PR TITLE
docs: fix metadata

### DIFF
--- a/docs/tutorialkit.dev/src/content/docs/reference/configuration.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/reference/configuration.mdx
@@ -162,7 +162,7 @@ terminal:
     - type: terminal
       id: 'cmds'
       title: 'Command Line'
-      allowRedirects: true,
+      allowRedirects: true
       allowCommands:
         - ls
         - echo


### PR DESCRIPTION
- Fixes broken metadata. When copying the example to existing project validation fails