### PR TITLE
fix(cli): normalize windows paths for `fast-glob`

### DIFF
--- a/packages/template/uno.config.ts
+++ b/packages/template/uno.config.ts
@@ -23,8 +23,8 @@ export default defineConfig({
   ...unoCSSConfig,
   content: {
     inline: globSync([
-      `${convertPathToPattern(join(require.resolve('@tutorialkit/components-react'), '..'))}/**/*.js`,
-      `${convertPathToPattern(join(require.resolve('@tutorialkit/astro'), '..'))}/default/**/*.astro`,
+      `${convertPathToPattern(join(require.resolve('@tutorialkit/components-react'), '..')).replace('\\@', '/@')}/**/*.js`,
+      `${convertPathToPattern(join(require.resolve('@tutorialkit/astro'), '..')).replace('\\@', '/@')}/default/**/*.astro`,
     ]).map((filePath) => {
       return () => fs.readFile(filePath, { encoding: 'utf8' });
     }),


### PR DESCRIPTION
- Fixes https://github.com/stackblitz/tutorialkit/issues/182
- Fixes https://github.com/stackblitz/tutorialkit/issues/183
- Ref. https://github.com/mrmlnc/fast-glob/issues/452

