### PR TITLE
chore: release `@tutorialkit` packages v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.1.1](https://github.com/stackblitz/tutorialkit/compare/0.1.0...0.1.1) (2024-07-30)
+
+
+### Bug Fixes
+
+* **cli:** normalize windows paths for `fast-glob` ([#184](https://github.com/stackblitz/tutorialkit/issues/184)) ([eaa9890](https://github.com/stackblitz/tutorialkit/commit/eaa9890da93169ec2e3249a6065501a1326b4df9))
+
+
+
 # [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) (2024-07-25)
 
 

--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.1](https://github.com/stackblitz/tutorialkit/compare/0.1.0...0.1.1) "@tutorialkit/astro" (2024-07-30)
+
+
+
 # [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) "@tutorialkit/astro" (2024-07-25)
 
 

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/astro",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TutorialKit integration for Astro (https://astro.build)",
   "author": "StackBlitz Inc.",
   "type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.1](https://github.com/stackblitz/tutorialkit/compare/0.1.0...0.1.1) "tutorialkit" (2024-07-30)
+
+
+
 # [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) "tutorialkit" (2024-07-25)
 
 

--- a/packages/components/react/CHANGELOG.md
+++ b/packages/components/react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.1](https://github.com/stackblitz/tutorialkit/compare/0.1.0...0.1.1) "@tutorialkit/components-react" (2024-07-30)
+
+
+
 # [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) "@tutorialkit/components-react" (2024-07-25)
 
 

--- a/packages/components/react/package.json
+++ b/packages/components/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/components-react",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TutorialKit's React components",
   "author": "StackBlitz Inc.",
   "type": "module",

--- a/packages/create-tutorial/CHANGELOG.md
+++ b/packages/create-tutorial/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.2](https://github.com/stackblitz/tutorialkit/compare/0.1.0...0.0.2) "create-tutorial" (2024-07-30)
+
+
+
 ## [0.0.2](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.0.2) "create-tutorial" (2024-07-25)
 
 

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.1](https://github.com/stackblitz/tutorialkit/compare/0.1.0...0.1.1) "@tutorialkit/runtime" (2024-07-30)
+
+
+
 # [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) "@tutorialkit/runtime" (2024-07-25)
 
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/runtime",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TutorialKit runtime",
   "author": "StackBlitz Inc.",
   "type": "module",

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.1](https://github.com/stackblitz/tutorialkit/compare/0.1.0...0.1.1) "@tutorialkit/theme" (2024-07-30)
+
+
+
 # [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) "@tutorialkit/theme" (2024-07-25)
 
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/theme",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TutorialKit theme configuration",
   "author": "StackBlitz Inc.",
   "type": "module",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.1](https://github.com/stackblitz/tutorialkit/compare/0.1.0...0.1.1) "@tutorialkit/types" (2024-07-30)
+
+
+
 # [0.1.0](https://github.com/stackblitz/tutorialkit/compare/0.0.3...0.1.0) "@tutorialkit/types" (2024-07-25)
 
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tutorialkit/types",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Types for TutorialKit",
   "author": "StackBlitz Inc.",
   "type": "module",


### PR DESCRIPTION
Bump `@tutorialkit` packages to version 0.1.1 and generate changelogs.