### PR TITLE
fix: ignore templates `node_modules`

### DIFF
--- a/packages/astro/src/webcontainer-files/constants.ts
+++ b/packages/astro/src/webcontainer-files/constants.ts
@@ -1,4 +1,4 @@
-export const IGNORED_FILES = ['**/.DS_Store', '**/*.swp'];
+export const IGNORED_FILES = ['**/.DS_Store', '**/*.swp', '**/node_modules/**'];
 export const EXTEND_CONFIG_FILEPATH = '/.tk-config.json';
 export const FILES_FOLDER_NAME = '_files';
 export const SOLUTION_FOLDER_NAME = '_solution';


### PR DESCRIPTION
- Fixes https://github.com/stackblitz/tutorialkit/issues/189

Fixes issues where users would see `jsh: permission denied` errors if `src/templates/*/node_modules` were present on host machines' file system. TutorialKit would copy those `node_modules` to webcontainers and try to run them. These `node_modules` may contain platform specific binaries that fail to run on webcontainers (non-wasm builds). 

Adds `node_modules` to be ignored in `src/templates`. At this point the change is hard-coded and not configurable. See https://github.com/stackblitz/tutorialkit/issues/189#issuecomment-2262036287.

I'll create a follow-up feature request that would allow including `node_modules`, so that tutorial authors could include pre-optimized dependencies in their templates. This is lower priority task compared to #189 that users are running into now.

