### PR TITLE
fix(astro): webcontainers link to be in plural

### DIFF
--- a/docs/tutorialkit.dev/src/content/docs/reference/configuration.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/reference/configuration.mdx
@@ -58,7 +58,7 @@ type I18nText = {
   /**
    * Text of the WebContainer link.
    *
-   * @default 'Powered by WebContainer'
+   * @default 'Powered by WebContainers'
    */
   webcontainerLinkText?: string,
 

--- a/packages/astro/src/default/utils/content/default-localization.ts
+++ b/packages/astro/src/default/utils/content/default-localization.ts
@@ -5,7 +5,7 @@ export const DEFAULT_LOCALIZATION = {
   noPreviewNorStepsText: 'No preview to run nor steps to show',
   startWebContainerText: 'Run this tutorial',
   editPageText: 'Edit this page',
-  webcontainerLinkText: 'Powered by WebContainer',
+  webcontainerLinkText: 'Powered by WebContainers',
   filesTitleText: 'Files',
   prepareEnvironmentTitleText: 'Preparing Environment',
   toggleTerminalButtonText: 'Toggle Terminal',

--- a/packages/types/src/schemas/i18n.ts
+++ b/packages/types/src/schemas/i18n.ts
@@ -18,7 +18,7 @@ export const i18nSchema = z.object({
   /**
    * Text of the WebContainer link.
    *
-   * @default 'Powered by WebContainer'
+   * @default 'Powered by WebContainers'
    */
   webcontainerLinkText: z.string().optional().describe('Text of the WebContainer link.'),
 


### PR DESCRIPTION
- Link should be in plural instead
- Ref. https://github.com/stackblitz/tutorialkit/pull/202#discussion_r1700841915
