### PR TITLE
chore: prepare extension changelog for 0.1.1

### DIFF
--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the "tutorialkit" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.1.1]
+
+All the following changes are for the Tutorial Panel:
+
+- Add the tutorial as the root element of the tree so that the root metadata can be viewed and edited easily
+- Add an "Add Part" action to the context menu of the root element
+- Add a "Delete" action to every context menu to remove a part, chapter or lesson
+- When the order is defined in the metadata, it is reflected in the panel
+- When a new part, chapter or lesson is created if the parent uses the order defined in the metadata, then it gets automatically added there.
+
 ## [0.1.0]
 
 - Add autocompletion in the metadata of TutorialKit markdown and mdx files (see: https://github.com/stackblitz/tutorialkit/pull/143)

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -4,7 +4,7 @@
   "description": "TutorialKit support in VS Code",
   "icon": "resources/tutorialkit-icon.png",
   "publisher": "StackBlitz",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "engines": {
     "vscode": "^1.80.0"
   },


### PR DESCRIPTION
In order to release the changes made the vscode extension we needed to update the changelog. This PR fixes that.