### PR TITLE
chore: remove spec files from runtime package

### DIFF
--- a/packages/astro/tsconfig.json
+++ b/packages/astro/tsconfig.json
@@ -9,9 +9,9 @@
   },
   "include": ["src"],
   "references": [
-    { "path": "../runtime" },
-    { "path": "../types" },
-    { "path": "../components/react" },
+    { "path": "../runtime/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../components/react/tsconfig.build.json" },
     { "path": "../theme" }
   ]
 }

--- a/packages/components/react/tsconfig.build.json
+++ b/packages/components/react/tsconfig.build.json
@@ -7,5 +7,9 @@
   },
   "include": ["src"],
   "exclude": ["src/**/*.spec.ts"],
-  "references": [{ "path": "../../runtime" }, { "path": "../../theme" }, { "path": "../../types" }]
+  "references": [
+    { "path": "../../runtime/tsconfig.build.json" },
+    { "path": "../../theme" },
+    { "path": "../../types/tsconfig.build.json" }
+  ]
 }

--- a/packages/components/react/tsconfig.json
+++ b/packages/components/react/tsconfig.json
@@ -9,5 +9,9 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "references": [{ "path": "../../runtime" }, { "path": "../../theme" }, { "path": "../../types" }]
+  "references": [
+    { "path": "../../runtime/tsconfig.build.json" },
+    { "path": "../../theme" },
+    { "path": "../../types/tsconfig.build.json" }
+  ]
 }

--- a/packages/runtime/tsconfig.build.json
+++ b/packages/runtime/tsconfig.build.json
@@ -7,5 +7,5 @@
   },
   "include": ["src"],
   "exclude": ["src/**/*.spec.ts"],
-  "references": [{ "path": "../types" }]
+  "references": [{ "path": "../types/tsconfig.build.json" }]
 }

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -6,5 +6,5 @@
     "composite": true
   },
   "include": ["src"],
-  "references": [{ "path": "../types" }, { "path": "../test-utils" }]
+  "references": [{ "path": "../types/tsconfig.build.json" }, { "path": "../test-utils" }]
 }


### PR DESCRIPTION
# Overview

Looking at the package, everything seemed like it should not include the spec files. After some investigation I found some strange behavior with the components package being included in the build 🤔. 

# Summary

Package does not respect the `tsconfig.build.json` when `@tutorialkit/components-react` is included in the `--filter`.

# Fix

The quick and dirty fix is to just exclude the `@tutorial/components-react` from the filter and have a two step build. It may need further triage with pnpm/typescript. Happy to dig deeper! 

- resolves #158 