### PR TITLE
fix(astro): don't modify state during re-renders of `<WorkspacePanelWrapper />`

### DIFF
--- a/packages/astro/src/default/components/WorkspacePanelWrapper.tsx
+++ b/packages/astro/src/default/components/WorkspacePanelWrapper.tsx
@@ -13,7 +13,7 @@ export function WorkspacePanelWrapper({ lesson }: Props) {
   const theme = useStore(themeStore);
 
   useEffect(() => {
-    tutorialStore.setLesson(lesson, { ssr: import.meta.env.SSR });
+    tutorialStore.setLesson(lesson);
   }, [lesson]);
 
   if (import.meta.env.SSR || !tutorialStore.lesson) {

--- a/packages/astro/src/default/components/WorkspacePanelWrapper.tsx
+++ b/packages/astro/src/default/components/WorkspacePanelWrapper.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useStore } from '@nanostores/react';
 import { WorkspacePanel } from '@tutorialkit/components-react';
 import type { Lesson } from '@tutorialkit/types';
@@ -11,7 +12,13 @@ interface Props {
 export function WorkspacePanelWrapper({ lesson }: Props) {
   const theme = useStore(themeStore);
 
-  tutorialStore.setLesson(lesson, { ssr: import.meta.env.SSR });
+  useEffect(() => {
+    tutorialStore.setLesson(lesson, { ssr: import.meta.env.SSR });
+  }, [lesson]);
+
+  if (import.meta.env.SSR || !tutorialStore.lesson) {
+    tutorialStore.setLesson(lesson, { ssr: import.meta.env.SSR });
+  }
 
   return <WorkspacePanel tutorialStore={tutorialStore} theme={theme} />;
 }

--- a/packages/components/react/src/Panels/PreviewPanel.tsx
+++ b/packages/components/react/src/Panels/PreviewPanel.tsx
@@ -134,6 +134,7 @@ export const PreviewPanel = memo(
     return createElement(PanelGroup, { id: 'preview-panel', direction: 'horizontal' }, ...children);
   }),
 );
+PreviewPanel.displayName = 'PreviewPanel';
 
 interface PreviewProps {
   iframe: IFrameRef;

--- a/packages/components/react/src/core/Terminal/index.tsx
+++ b/packages/components/react/src/core/Terminal/index.tsx
@@ -83,4 +83,5 @@ export const Terminal = forwardRef<TerminalRef, TerminalProps>(
   },
 );
 
+Terminal.displayName = 'Terminal';
 export default Terminal;


### PR DESCRIPTION
Fixes React's state warning that happen when navigating between pages. `setLesson` that's done inside rendering block attempts to update state of the components that are just about to unmount.

```
Warning: Cannot update a component (`PreviewPanel`) while rendering a different component (`WorkspacePanelWrapper`). To locate the bad setState() call inside `WorkspacePanelWrapper`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render
    at WorkspacePanelWrapper (http://localhost:4321/@fs/Users/x/tutorialkit/packages/astro/dist/default/components/WorkspacePanelWrapper.tsx:23:41)

printWarning                        @    react-dom.development.js:86
error                               @    react-dom.development.js:60
warnAboutRenderPhaseUpdatesInDEV    @    react-dom.development.js:27531
scheduleUpdateOnFiber               @    react-dom.development.js:25537
forceStoreRerender                  @    react-dom.development.js:16158
handleStoreChange                   @    react-dom.development.js:16134
notify                              @    index.js:55
set                                 @    index.js:72
setPreviews                         @    previews.js:77
setLesson                           @    index.js:96
WorkspacePanelWrapper               @    WorkspacePanelWrapper.tsx:15
```

