### PR TITLE
fix(extension): only match tutorialkit content and meta files

### DIFF
--- a/extensions/vscode/src/language-server/index.ts
+++ b/extensions/vscode/src/language-server/index.ts
@@ -25,14 +25,7 @@ connection.onInitialize((params) => {
           {
             uri: 'https://tutorialkit.dev/reference/configuration',
             schema,
-            fileMatch: [
-              '**/*',
-
-              // TODO: these don't work
-              'src/content/*.md',
-              'src/content/**/*.md',
-              'src/content/**/*.mdx',
-            ],
+            fileMatch: ['volar-embedded-content://tutorialkit_frontmatter/**/*'],
             priority: SchemaPriority.Settings,
           },
         ],

--- a/extensions/vscode/src/language-server/languagePlugin.ts
+++ b/extensions/vscode/src/language-server/languagePlugin.ts
@@ -1,11 +1,20 @@
 import { CodeMapping, type LanguagePlugin, type VirtualCode } from '@volar/language-core';
 import type * as ts from 'typescript';
 import type { URI } from 'vscode-uri';
+import { FILES_FOLDER, SOLUTION_FOLDER } from '../models/tree/constants';
 
-export function frontmatterPlugin(debug: (message: string) => void): LanguagePlugin<URI> {
+export function frontmatterPlugin(_debug: (message: string) => void): LanguagePlugin<URI> {
   return {
     getLanguageId(uri) {
-      debug('URI: ' + uri.path);
+      // only match markdown files inside the src/content/tutorial folder
+      if (!uri.path.match(/.*src\/content\/tutorial\/.*(content|meta)\.mdx?$/)) {
+        return undefined;
+      }
+
+      // but ignore all files under _files or _solution
+      if (uri.path.includes(FILES_FOLDER) || uri.path.includes(SOLUTION_FOLDER)) {
+        return undefined;
+      }
 
       if (uri.path.endsWith('.md')) {
         return 'markdown';
@@ -74,7 +83,7 @@ function* frontMatterCode(snapshot: ts.IScriptSnapshot): Generator<VirtualCode> 
   const frontMatterText = content.substring(frontMatterStartIndex, frontMatterEndIndex);
 
   yield {
-    id: 'frontmatter_1',
+    id: 'tutorialkit_frontmatter',
     languageId: 'yaml',
     snapshot: {
       getText: (start, end) => frontMatterText.slice(start, end),

--- a/extensions/vscode/src/language-server/languagePlugin.ts
+++ b/extensions/vscode/src/language-server/languagePlugin.ts
@@ -6,16 +6,6 @@ import { FILES_FOLDER, SOLUTION_FOLDER } from '../models/tree/constants';
 export function frontmatterPlugin(_debug: (message: string) => void): LanguagePlugin<URI> {
   return {
     getLanguageId(uri) {
-      // only match markdown files inside the src/content/tutorial folder
-      if (!uri.path.match(/.*src\/content\/tutorial\/.*(content|meta)\.mdx?$/)) {
-        return undefined;
-      }
-
-      // but ignore all files under _files or _solution
-      if (uri.path.includes(FILES_FOLDER) || uri.path.includes(SOLUTION_FOLDER)) {
-        return undefined;
-      }
-
       if (uri.path.endsWith('.md')) {
         return 'markdown';
       }
@@ -26,7 +16,17 @@ export function frontmatterPlugin(_debug: (message: string) => void): LanguagePl
 
       return undefined;
     },
-    createVirtualCode(_uri, languageId, snapshot) {
+    createVirtualCode(uri, languageId, snapshot) {
+      // only match markdown files inside the src/content/tutorial folder
+      if (!uri.path.match(/.*src\/content\/tutorial\/.*(content|meta)\.mdx?$/)) {
+        return undefined;
+      }
+
+      // but ignore all files under _files or _solution
+      if (uri.path.includes(FILES_FOLDER) || uri.path.includes(SOLUTION_FOLDER)) {
+        return undefined;
+      }
+
       if (languageId === 'markdown' || languageId === 'mdx') {
         return new FrontMatterVirtualCode(snapshot);
       }


### PR DESCRIPTION
This PR makes sure that the autocompletion and validation for the frontmatter applies primarily to files that should be within a tutorialkit project. The heuristic used is very simple and not perfect so there could still be false positive. However, after this PR it will become very unlikely as one would need to create a markdown file named `meta.md` or `content.md(x)` under a `src/content/tutorial` path.

Note that files under `_files` and `_solution` are ignored as this could be a common situation where the extension would incorrectly perform validation and provide autocompletions.

Closes #237
