### PR TITLE
fix(cli): `create-tutorial` not depending on `@tutorialkit/cli` package

### DIFF
--- a/packages/create-tutorial/src/index.ts
+++ b/packages/create-tutorial/src/index.ts
@@ -4,6 +4,6 @@ import { spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const tutorialKitEntryPoint = require.resolve('tutorialkit');
+const tutorialKitEntryPoint = require.resolve('@tutorialkit/cli');
 
 spawnSync('node', [tutorialKitEntryPoint, 'create', ...process.argv.slice(2)], { stdio: 'inherit' });


### PR DESCRIPTION
Rename `tutorialkit` to `@tutorialkit/cli` missing in #153.

The PR #153 has been renamed the `@tutorialkit/cli` dependency in `package.json`, but no changed in `index.ts`, if now running locally will see the error: `Error: Cannot find module 'tutorialkit'`, so this PR is fixed this.