### PR TITLE
feat: add Vue language to CodeMirror

### DIFF
--- a/packages/components/react/package.json
+++ b/packages/components/react/package.json
@@ -62,6 +62,7 @@
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/lang-markdown": "^6.2.5",
     "@codemirror/lang-sass": "^6.0.2",
+    "@codemirror/lang-vue": "^0.1.3",
     "@codemirror/lang-wast": "^6.0.2",
     "@codemirror/language": "^6.10.2",
     "@codemirror/state": "^6.4.1",

--- a/packages/components/react/src/core/CodeMirrorEditor/languages.ts
+++ b/packages/components/react/src/core/CodeMirrorEditor/languages.ts
@@ -79,6 +79,13 @@ export const supportedLanguages = [
     },
   }),
   LanguageDescription.of({
+    name: 'Vue',
+    extensions: ['vue'],
+    async load() {
+      return import('@codemirror/lang-vue').then((module) => module.vue());
+    },
+  }),
+  LanguageDescription.of({
     name: 'Svelte',
     extensions: ['svelte'],
     async load() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,6 +442,9 @@ importers:
       '@codemirror/lang-sass':
         specifier: ^6.0.2
         version: 6.0.2(@codemirror/view@6.28.1)
+      '@codemirror/lang-vue':
+        specifier: ^0.1.3
+        version: 0.1.3
       '@codemirror/lang-wast':
         specifier: ^6.0.2
         version: 6.0.2
@@ -1510,6 +1513,17 @@ packages:
       '@lezer/sass': 1.0.6
     transitivePeerDependencies:
       - '@codemirror/view'
+    dev: false
+
+  /@codemirror/lang-vue@0.1.3:
+    resolution: {integrity: sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==}
+    dependencies:
+      '@codemirror/lang-html': 6.4.9
+      '@codemirror/lang-javascript': 6.2.2
+      '@codemirror/language': 6.10.2
+      '@lezer/common': 1.2.1
+      '@lezer/highlight': 1.2.0
+      '@lezer/lr': 1.4.1
     dev: false
 
   /@codemirror/lang-wast@6.0.2:


### PR DESCRIPTION
Add Vue language ([`@codemirror/lang-vue`](https://github.com/codemirror/lang-vue)) into [CodeMirrorEditor/languages.ts](https://github.com/stackblitz/tutorialkit/blob/main/packages/components/react/src/core/CodeMirrorEditor/languages.ts).

### Screenshot

![螢幕擷取畫面 2024-08-18 193513](https://github.com/user-attachments/assets/05fe66be-d2d5-4c8b-9b97-83292b06413b)
