### PR TITLE
fix(astro/types): `webcontainer` should be a `Promise<WebContainer>`

### DIFF
--- a/packages/astro/types.d.ts
+++ b/packages/astro/types.d.ts
@@ -5,5 +5,5 @@ declare module 'tutorialkit:store' {
 }
 
 declare module 'tutorialkit:core' {
-  export const webcontainer: import('@webcontainer/api').WebContainer;
+  export const webcontainer: Promise<import('@webcontainer/api').WebContainer>;
 }


### PR DESCRIPTION
This PR fixes the type of `webcontainer` in `@tutorialkit/astro/types` to be `Promise<WebContainer>` and not `WebContainer`.