### PR TITLE
chore: release `create-tutorial` v0.0.3

### DIFF
--- a/packages/create-tutorial/package.json
+++ b/packages/create-tutorial/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-tutorial",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Interactive tutorials powered by WebContainer API",
   "author": "StackBlitz Inc.",
   "type": "module",


### PR DESCRIPTION
Bump `create-tutorial` to version 0.0.3.