### PR TITLE
fix(react): solve-button not working before lesson loads

### DIFF
--- a/packages/components/react/src/Panels/EditorPanel.tsx
+++ b/packages/components/react/src/Panels/EditorPanel.tsx
@@ -125,7 +125,7 @@ function FileTab({ i18n, editorDocument, helpAction, onHelpClick }: FileTabProps
         <span className="text-sm">{fileName}</span>
       </div>
       {!!helpAction && (
-        <button onClick={onHelpClick} className="panel-button px-2 py-0.5 -mr-1 -my-1">
+        <button onClick={onHelpClick} disabled={!onHelpClick} className="panel-button px-2 py-0.5 -mr-1 -my-1">
           {helpAction === 'solve' && <div className="i-ph-lightbulb-duotone text-lg" />}
           {helpAction === 'solve' && i18n.solveButtonText}
           {helpAction === 'reset' && <div className="i-ph-clock-counter-clockwise-duotone" />}

--- a/packages/components/react/src/Panels/WorkspacePanel.tsx
+++ b/packages/components/react/src/Panels/WorkspacePanel.tsx
@@ -40,6 +40,7 @@ export function WorkspacePanel({ tutorialStore, theme }: Props) {
 
   const selectedFile = useStore(tutorialStore.selectedFile);
   const currentDocument = useStore(tutorialStore.currentDocument);
+  const lessonFullyLoaded = useStore(tutorialStore.lessonFullyLoaded);
 
   const lesson = tutorialStore.lesson!;
 
@@ -162,7 +163,7 @@ export function WorkspacePanel({ tutorialStore, theme }: Props) {
           i18n={lesson.data.i18n as I18n}
           hideRoot={lesson.data.hideRoot}
           helpAction={helpAction}
-          onHelpClick={onHelpClick}
+          onHelpClick={lessonFullyLoaded ? onHelpClick : undefined}
           onFileSelect={onFileSelect}
           selectedFile={selectedFile}
           onEditorScroll={onEditorScroll}


### PR DESCRIPTION
- Split from https://github.com/stackblitz/tutorialkit/pull/241

If Solve-button is clicked quickly enough, it does not reveal the solution files. It does change the button text to "Reset" which is not true in that case.

https://github.com/stackblitz/tutorialkit/blob/095ed570702d1b8de9370565b94103cd0740c408/packages/runtime/src/store/index.ts#L290-L295