### PR TITLE
fix(react): editor and preview missing accessible names

### DIFF
--- a/packages/components/react/src/Panels/PreviewPanel.tsx
+++ b/packages/components/react/src/Panels/PreviewPanel.tsx
@@ -160,6 +160,10 @@ function Preview({ preview, iframe, previewCount, first, last, toggleTerminal, i
     if (preview.url) {
       iframe.ref.src = preview.url;
     }
+
+    if (preview.title) {
+      iframe.ref.title = preview.title;
+    }
   }, [preview.url, iframe.ref]);
 
   return (

--- a/packages/components/react/src/core/CodeMirrorEditor/index.tsx
+++ b/packages/components/react/src/core/CodeMirrorEditor/index.tsx
@@ -208,6 +208,7 @@ function newEditorState(
   return EditorState.create({
     doc: content,
     extensions: [
+      EditorView.contentAttributes.of({ 'aria-label': 'Editor' }),
       EditorView.domEventHandlers({
         scroll: debounce((_event, view) => {
           onScrollRef.current?.({ left: view.scrollDOM.scrollLeft, top: view.scrollDOM.scrollTop });


### PR DESCRIPTION
- Split from https://github.com/stackblitz/tutorialkit/pull/241

Adds accessible names for editor and preview so that users with assistive technologies can identify the elements. 