### PR TITLE
ci: setup pkg.pr.new

### DIFF
--- a/.github/workflows/publish-commit.yaml
+++ b/.github/workflows/publish-commit.yaml
@@ -1,0 +1,71 @@
+# Publishes main-branch's commits to pkg.pr.new
+# PRs can be published by commenting `/pkg-pr-new` in the PR
+
+name: Publish Any Commit
+
+on:
+  push:
+    branches:
+      - main
+  issue_comment:
+    types: [created]
+
+jobs:
+  build:
+    if: github.repository == 'stackblitz/tutorialkit' && (github.event_name == 'push' || github.event.issue.pull_request && startsWith(github.event.comment.body, '/pkg-pr-new'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - if: github.event.issue.pull_request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const user = context.payload.sender.login
+            console.log(`Validate user: ${user}`)
+
+            let hasTriagePermission = false
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: user,
+              });
+              hasTriagePermission = data.user.permissions.triage
+            } catch (e) {
+              console.warn(e)
+            }
+
+            if (hasTriagePermission) {
+              console.log('Allowed')
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: '+1',
+              })
+            } else {
+              console.log('Not allowed')
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: '-1',
+              })
+              throw new Error('not allowed')
+            }
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-and-build
+
+      - name: Publish to pkg.pr.new
+        run: >
+          pnpm dlx pkg-pr-new@0.0 publish --compact --pnpm
+          ./packages/astro
+          ./packages/components/react
+          ./packages/runtime
+          ./packages/theme
+          ./packages/types


### PR DESCRIPTION
- Adds https://pkg.pr.new to TutorialKit repo
- All commits pushed to `main` trigger an automatic release
- Maintainers can trigger a release by commenting `/pkg-pr-new` in a PR

This will make testing PRs like https://github.com/stackblitz/tutorialkit/pull/270 a lot easier. In that PR we need to verify that packages are resolved correctly in real environments. Testing such changes by linking packages with `file://` or `link://` protocols in `package.json` doesn't provide good confidence - using real published packages is better.

I've used the workflow from Vite as reference: https://github.com/vitejs/vite/blob/main/.github/workflows/publish-commit.yml

