### PR TITLE
chore: rename import `@tutorialkit/test-utils` to `test-utils`

### DIFF
--- a/packages/runtime/src/tutorial-runner.spec.ts
+++ b/packages/runtime/src/tutorial-runner.spec.ts
@@ -1,8 +1,8 @@
 // must be imported first
-import { resetProcessFactory, setProcessFactory } from '@tutorialkit/test-utils';
+import { resetProcessFactory, setProcessFactory } from 'test-utils';
 
 import { WebContainer } from '@webcontainer/api';
-import type { MockedWebContainer } from '@tutorialkit/test-utils';
+import type { MockedWebContainer } from 'test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { TerminalStore } from './store/terminal.js';
 import { TutorialRunner } from './tutorial-runner.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "noImplicitReturns": true,
     "strict": true,
     "paths": {
-      "@tutorialkit/test-utils": ["./packages/test-utils/src/index.ts"]
+      "test-utils": ["./packages/test-utils/src/index.ts"]
     }
   }
 }


### PR DESCRIPTION
This PR reverts the renaming of the import back to how it was: `test-utils` (was renamed to `@tutorialkit/test-utils` in #141).

This change aligns better with conventions we have in other repositories and also makes it easier to find what the import correspond to given the name of the package is `test-utils` and not `@tutorialkit/test-utils`. Note that we could instead change that package name to be `@tutorialkit/test-utils` but this is not a desirable change we want given it's not meant to be published.