### PR TITLE
ci: checkout to PR branch

### DIFF
--- a/.github/workflows/publish-commit.yaml
+++ b/.github/workflows/publish-commit.yaml
@@ -1,12 +1,8 @@
-# Publishes main-branch's commits to pkg.pr.new
 # PRs can be published by commenting `/pkg-pr-new` in the PR
 
 name: Publish Any Commit
 
 on:
-  push:
-    branches:
-      - main
   issue_comment:
     types: [created]
 
@@ -57,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: refs/pull/${{ github.event.issue.number }}/head
 
       - uses: ./.github/actions/setup-and-build
 


### PR DESCRIPTION
- The `issue_comment` event doesn't happen on given PR so we'll need to checkout to the PR manually