### PR TITLE
docs: tutorialkit.dev link in readme

### DIFF
--- a/docs/tutorialkit.dev/README.md
+++ b/docs/tutorialkit.dev/README.md
@@ -1,4 +1,4 @@
-# [TutorialKit.dev](https://www.tutorialkit.dev)
+# [TutorialKit.dev](https://tutorialkit.dev)
 
 ## Local Development
 


### PR DESCRIPTION
https://www.tutorialkit.dev (with www) doesn't work