### PR TITLE
docs: change the clone url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Hi! We are really excited that you are interested in contributing to TutorialKit
 
 ## Repo Setup
 
-The TutorialKit repo is a monorepo using pnpm workspaces. The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/). pnpm version 8.15.6 is required (npm i -g pnpm@8.15.6)
+The TutorialKit repo is a monorepo using pnpm workspaces. The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/). Package manager versioning is handled by [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field that's supported by [Node's Corepack](https://nodejs.org/api/corepack.html) and other tools.
 
 To develop and test packages:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Hi! We are really excited that you are interested in contributing to TutorialKit
 
 ## Repo Setup
 
-The TutorialKit repo is a monorepo using pnpm workspaces. The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/). Package manager versioning is handled by [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field that's supported by [Node's Corepack](https://nodejs.org/api/corepack.html) and other tools. You can find the specific pnpm version required at: https://github.com/stackblitz/tutorialkit/blob/main/package.json#L23
+The TutorialKit repo is a monorepo using pnpm workspaces. The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/). Package manager versioning is handled by [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field that's supported by [Node's Corepack](https://nodejs.org/api/corepack.html) and other tools.
 
 To develop and test packages:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,14 @@ Hi! We are really excited that you are interested in contributing to TutorialKit
 
 ## Repo Setup
 
-The TutorialKit repo is a monorepo using pnpm workspaces. The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/).
+The TutorialKit repo is a monorepo using pnpm workspaces. The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/). pnpm version 8.15.6 is required (npm i -g pnpm@8.15.6)
 
 To develop and test packages:
 
 1. Clone this repository and navigate into the cloned directory.
 
 ```
-git clone git@github.com:stackblitz/tutorialkit.git
+git clone https://github.com/stackblitz/tutorialkit
 cd tutorialkit
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Hi! We are really excited that you are interested in contributing to TutorialKit
 
 ## Repo Setup
 
-The TutorialKit repo is a monorepo using pnpm workspaces. The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/). Package manager versioning is handled by [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field that's supported by [Node's Corepack](https://nodejs.org/api/corepack.html) and other tools.
+The TutorialKit repo is a monorepo using pnpm workspaces. The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/). Package manager versioning is handled by [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field that's supported by [Node's Corepack](https://nodejs.org/api/corepack.html) and other tools. You can find the specific pnpm version required at: https://github.com/stackblitz/tutorialkit/blob/main/package.json#L23
 
 To develop and test packages:
 


### PR DESCRIPTION
 the git@github.com didn't work on my machine

Also - when trying to set this up, it required the specific pnpm@8.15.6 for some reason - so I've added that to the document