### PR TITLE
feat: add files via file tree

### DIFF
--- a/docs/tutorialkit.dev/src/components/react-examples/ExampleFileTree.tsx
+++ b/docs/tutorialkit.dev/src/components/react-examples/ExampleFileTree.tsx
@@ -14,7 +14,7 @@ export default function ExampleFileTree() {
       selectedFile={selectedFile}
       onFileSelect={setSelectedFile}
       onFileChange={(event) => {
-        if (event.method === 'ADD') {
+        if (event.method === 'add') {
           setFiles([...files, { path: event.value, type: event.type }].sort());
         }
       }}

--- a/docs/tutorialkit.dev/src/components/react-examples/ExampleFileTree.tsx
+++ b/docs/tutorialkit.dev/src/components/react-examples/ExampleFileTree.tsx
@@ -15,7 +15,7 @@ export default function ExampleFileTree() {
       onFileSelect={setSelectedFile}
       onFileChange={(event) => {
         if (event.method === 'add') {
-          setFiles([...files, { path: event.value, type: event.type }].sort());
+          setFiles([...files, { path: event.value, type: event.type }]);
         }
       }}
     />

--- a/docs/tutorialkit.dev/src/components/react-examples/ExampleFileTree.tsx
+++ b/docs/tutorialkit.dev/src/components/react-examples/ExampleFileTree.tsx
@@ -2,25 +2,31 @@ import { useState } from 'react';
 import FileTree from '@tutorialkit/react/core/FileTree';
 
 export default function ExampleFileTree() {
-  const [selectedFile, setSelectedFile] = useState(FILES[0]);
+  const [files, setFiles] = useState(INITIAL_FILES);
+  const [selectedFile, setSelectedFile] = useState(INITIAL_FILES[0]);
 
   return (
     <FileTree
-      files={FILES}
+      files={files}
       hideRoot
       className="my-file-tree"
       hiddenFiles={['package-lock.json']}
       selectedFile={selectedFile}
       onFileSelect={setSelectedFile}
+      onFileChange={(event) => {
+        if (event.method === 'ADD') {
+          setFiles([...files, event.value].sort());
+        }
+      }}
     />
   );
 }
 
-const FILES = [
-  '/src/index.js',
-  '/src/index.html',
-  '/src/assets/logo.svg',
+const INITIAL_FILES = [
   '/package-lock.json',
   '/package.json',
+  '/src/assets/logo.svg',
+  '/src/index.html',
+  '/src/index.js',
   '/vite.config.js',
 ];

--- a/docs/tutorialkit.dev/src/components/react-examples/ExampleFileTree.tsx
+++ b/docs/tutorialkit.dev/src/components/react-examples/ExampleFileTree.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useState, type ComponentProps } from 'react';
 import FileTree from '@tutorialkit/react/core/FileTree';
 
 export default function ExampleFileTree() {
   const [files, setFiles] = useState(INITIAL_FILES);
-  const [selectedFile, setSelectedFile] = useState(INITIAL_FILES[0]);
+  const [selectedFile, setSelectedFile] = useState(INITIAL_FILES[0].path);
 
   return (
     <FileTree
@@ -15,18 +15,18 @@ export default function ExampleFileTree() {
       onFileSelect={setSelectedFile}
       onFileChange={(event) => {
         if (event.method === 'ADD') {
-          setFiles([...files, event.value].sort());
+          setFiles([...files, { path: event.value, type: event.type }].sort());
         }
       }}
     />
   );
 }
 
-const INITIAL_FILES = [
-  '/package-lock.json',
-  '/package.json',
-  '/src/assets/logo.svg',
-  '/src/index.html',
-  '/src/index.js',
-  '/vite.config.js',
+const INITIAL_FILES: ComponentProps<typeof FileTree>['files'] = [
+  { path: '/package-lock.json', type: 'FILE' },
+  { path: '/package.json', type: 'FILE' },
+  { path: '/src/assets/logo.svg', type: 'FILE' },
+  { path: '/src/index.html', type: 'FILE' },
+  { path: '/src/index.js', type: 'FILE' },
+  { path: '/vite.config.js', type: 'FILE' },
 ];

--- a/docs/tutorialkit.dev/src/components/react-examples/ExampleFileTree.tsx
+++ b/docs/tutorialkit.dev/src/components/react-examples/ExampleFileTree.tsx
@@ -23,10 +23,10 @@ export default function ExampleFileTree() {
 }
 
 const INITIAL_FILES: ComponentProps<typeof FileTree>['files'] = [
-  { path: '/package-lock.json', type: 'FILE' },
-  { path: '/package.json', type: 'FILE' },
-  { path: '/src/assets/logo.svg', type: 'FILE' },
-  { path: '/src/index.html', type: 'FILE' },
-  { path: '/src/index.js', type: 'FILE' },
-  { path: '/vite.config.js', type: 'FILE' },
+  { path: '/package-lock.json', type: 'file' },
+  { path: '/package.json', type: 'file' },
+  { path: '/src/assets/logo.svg', type: 'file' },
+  { path: '/src/index.html', type: 'file' },
+  { path: '/src/index.js', type: 'file' },
+  { path: '/vite.config.js', type: 'file' },
 ];

--- a/docs/tutorialkit.dev/src/components/react-examples/ExampleSimpleEditor.tsx
+++ b/docs/tutorialkit.dev/src/components/react-examples/ExampleSimpleEditor.tsx
@@ -227,7 +227,7 @@ const FILES: Record<string, EditorDocument> = {
   },
 };
 
-const FILE_PATHS = Object.keys(FILES).map((path) => ({ path, type: 'FILE' }));
+const FILE_PATHS = Object.keys(FILES).map((path) => ({ path, type: 'FILE' }) as const);
 
 function stripIndent(string: string) {
   const indent = minIndent(string.slice(1));

--- a/docs/tutorialkit.dev/src/components/react-examples/ExampleSimpleEditor.tsx
+++ b/docs/tutorialkit.dev/src/components/react-examples/ExampleSimpleEditor.tsx
@@ -227,7 +227,7 @@ const FILES: Record<string, EditorDocument> = {
   },
 };
 
-const FILE_PATHS = Object.keys(FILES).map((path) => ({ path, type: 'FILE' }) as const);
+const FILE_PATHS = Object.keys(FILES).map((path) => ({ path, type: 'file' }) as const);
 
 function stripIndent(string: string) {
   const indent = minIndent(string.slice(1));

--- a/docs/tutorialkit.dev/src/components/react-examples/ExampleSimpleEditor.tsx
+++ b/docs/tutorialkit.dev/src/components/react-examples/ExampleSimpleEditor.tsx
@@ -227,7 +227,7 @@ const FILES: Record<string, EditorDocument> = {
   },
 };
 
-const FILE_PATHS = Object.keys(FILES);
+const FILE_PATHS = Object.keys(FILES).map((path) => ({ path, type: 'FILE' }));
 
 function stripIndent(string: string) {
   const indent = minIndent(string.slice(1));

--- a/docs/tutorialkit.dev/src/content/docs/reference/configuration.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/reference/configuration.mdx
@@ -134,8 +134,34 @@ Defines which file should be opened in the [code editor](/guides/ui/#code-editor
 <PropertyTable inherited type="string" />
 
 ##### `editor`
-Configure whether or not the editor should be rendered. If an object is provided with `fileTree: false`, only the file tree is hidden.
-<PropertyTable inherited type="boolean | { fileTree: false }" />
+Configures options for the editor and its file tree. Editor can be hidden by providing `false`.
+Optionally you can hide just file tree by providing `fileTree: false`.
+
+File tree can be set to allow file editing from right clicks by setting `fileTree.allowEdits: true`.
+
+<PropertyTable inherited type={'Editor'} />
+
+The `Editor` type has the following shape:
+
+```ts
+type Editor =
+    | false
+    | { editor: { allowEdits: boolean } }
+
+```
+
+Example values:
+
+```yaml
+editor: false # Editor is hidden
+
+editor: # Editor is visible
+  fileTree: false # File tree is hidden
+
+editor: # Editor is visible
+  fileTree: # File tree is visible
+    allowEdits: true # User can add new files and folders from the file tree
+```
 
 ##### `previews`
 Configure which ports should be used for the previews allowing you to align the behavior with your demo application's dev server setup. If not specified, the lowest port will be used.

--- a/docs/tutorialkit.dev/src/content/docs/reference/react-components.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/reference/react-components.mdx
@@ -111,7 +111,7 @@ A component to list files in a tree view.
   ```ts
   interface FileChangeEvent {
     type: 'file' | 'folder';
-    method: 'ADD' | 'REMOVE' | 'RENAME';
+    method: 'add' | 'remove' | 'rename';
     value: string;
   }
   ```

--- a/docs/tutorialkit.dev/src/content/docs/reference/react-components.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/reference/react-components.mdx
@@ -110,7 +110,7 @@ A component to list files in a tree view.
 * `onFileChange: (event: FileChangeEvent) => void` - An optional callback that will be called when a new file or folder is created from the file tree's context menu. When callback is not passed, file tree does not allow adding new files.
   ```ts
   interface FileChangeEvent {
-    type: 'FILE' | 'FOLDER';
+    type: 'file' | 'folder';
     method: 'ADD' | 'REMOVE' | 'RENAME';
     value: string;
   }

--- a/docs/tutorialkit.dev/src/content/docs/reference/react-components.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/reference/react-components.mdx
@@ -107,11 +107,22 @@ A component to list files in a tree view.
 
 * `onFileSelect: (file: string) => void` - A callback that will be called when a file is clicked. The path of the file that was clicked will be passed as an argument.
 
+* `onFileChange: (event: FileChangeEvent) => void` - An optional callback that will be called when a new file or folder is created from the file tree's context menu. When callback is not passed, file tree does not allow adding new files.
+  ```ts
+  interface FileChangeEvent {
+    type: 'FILE' | 'FOLDER';
+    method: 'ADD' | 'REMOVE' | 'RENAME';
+    value: string;
+  }
+  ```
+
 * `hideRoot: boolean` - Whether or not to hide the root directory in the tree. Defaults to `false`.
 
 * `hiddenFiles: (string | RegExp)[]` - A list of file paths that should be hidden from the tree.
 
 * `scope?: string` - Every file path that does not start with this scope will be hidden.
+
+* `i18n?: object` - Texts for file tree's components.
 
 * `className?: string` - A class name to apply to the root element of the component.
 

--- a/e2e/src/content/tutorial/tests/file-tree/allow-edits-disabled/_files/first-level/file.js
+++ b/e2e/src/content/tutorial/tests/file-tree/allow-edits-disabled/_files/first-level/file.js
@@ -1,0 +1,1 @@
+export default 'File in first level';

--- a/e2e/src/content/tutorial/tests/file-tree/allow-edits-disabled/_files/first-level/second-level/file.js
+++ b/e2e/src/content/tutorial/tests/file-tree/allow-edits-disabled/_files/first-level/second-level/file.js
@@ -1,0 +1,1 @@
+export default 'File in second level';

--- a/e2e/src/content/tutorial/tests/file-tree/allow-edits-disabled/content.md
+++ b/e2e/src/content/tutorial/tests/file-tree/allow-edits-disabled/content.md
@@ -1,0 +1,11 @@
+---
+type: lesson
+title: Allow Edits Disabled
+previews: false
+terminal:
+  panels: terminal
+---
+
+# File Tree test - Allow Edits Disabled
+
+Option `editor.fileTree.allowEdits` has default `false` value.

--- a/e2e/src/content/tutorial/tests/file-tree/allow-edits-enabled/_files/first-level/file.js
+++ b/e2e/src/content/tutorial/tests/file-tree/allow-edits-enabled/_files/first-level/file.js
@@ -1,0 +1,1 @@
+export default 'File in first level';

--- a/e2e/src/content/tutorial/tests/file-tree/allow-edits-enabled/_files/first-level/second-level/file.js
+++ b/e2e/src/content/tutorial/tests/file-tree/allow-edits-enabled/_files/first-level/second-level/file.js
@@ -1,0 +1,1 @@
+export default 'File in second level';

--- a/e2e/src/content/tutorial/tests/file-tree/allow-edits-enabled/content.md
+++ b/e2e/src/content/tutorial/tests/file-tree/allow-edits-enabled/content.md
@@ -1,0 +1,12 @@
+---
+type: lesson
+title: Allow Edits Enabled
+previews: false
+editor:
+  fileTree:
+    allowEdits: true
+terminal:
+  panels: terminal
+---
+
+# File Tree test - Allow Edits Enabled

--- a/e2e/src/content/tutorial/tests/file-tree/hidden/_files/example.js
+++ b/e2e/src/content/tutorial/tests/file-tree/hidden/_files/example.js
@@ -1,0 +1,1 @@
+export default 'Lesson file example.js content';

--- a/e2e/src/content/tutorial/tests/file-tree/hidden/content.md
+++ b/e2e/src/content/tutorial/tests/file-tree/hidden/content.md
@@ -1,0 +1,9 @@
+---
+type: lesson
+title: Hidden
+editor:
+  fileTree: false
+focus: /example.js
+---
+
+# File Tree test - Hidden

--- a/e2e/test/file-tree.test.ts
+++ b/e2e/test/file-tree.test.ts
@@ -57,3 +57,101 @@ test('user can see cannot click solve on lessons without solution files', async 
   // reset-button should be immediately visible
   await expect(page.getByRole('button', { name: 'Reset' })).toBeVisible();
 });
+
+// TODO: Requires #245
+test.skip('user should not see hidden file tree', async ({ page }) => {
+  await page.goto(`${BASE_URL}/hidden`);
+  await expect(page.getByRole('heading', { level: 1, name: 'File Tree test - Hidden' })).toBeVisible();
+
+  await expect(page.getByText('Files')).not.toBeVisible();
+  await expect(page.getByRole('button', { name: 'example.js' })).not.toBeVisible();
+});
+
+test('user cannot create files or folders when lesson is not configured via allowEdits', async ({ page }) => {
+  await page.goto(`${BASE_URL}/allow-edits-disabled`);
+
+  await expect(page.getByTestId('file-tree-root-context-menu')).not.toBeVisible();
+
+  await page.getByRole('button', { name: 'first-level' }).click({ button: 'right' });
+  await expect(page.getByRole('menuitem', { name: 'Create file' })).not.toBeVisible();
+});
+
+test('user can create files', async ({ page }) => {
+  await page.goto(`${BASE_URL}/allow-edits-enabled`);
+  await expect(page.getByRole('heading', { level: 1, name: 'File Tree test - Allow Edits Enabled' })).toBeVisible();
+
+  // wait for terminal to start
+  const terminal = page.getByRole('textbox', { name: 'Terminal input' });
+  const terminalOutput = page.getByRole('tabpanel', { name: 'Terminal' });
+  await expect(terminalOutput).toContainText('~/tutorial', { useInnerText: true });
+
+  for (const [locator, filename] of [
+    [page.getByTestId('file-tree-root-context-menu'), 'file-in-root.js'],
+    [page.getByRole('button', { name: 'first-level' }), 'file-in-first-level.js'],
+    [page.getByRole('button', { name: 'second-level' }), 'file-in-second-level.js'],
+  ] as const) {
+    await locator.click({ button: 'right' });
+    await page.getByRole('menuitem', { name: 'Create file' }).click();
+
+    await page.locator('*:focus').fill(filename);
+    await page.locator('*:focus').press('Enter');
+    await expect(page.getByRole('button', { name: filename, pressed: true })).toBeVisible();
+  }
+
+  // verify that all files are present on file tree after last creation
+  await expect(page.getByRole('button', { name: 'file-in-root.js' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'file-in-first-level' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'file-in-second-level' })).toBeVisible();
+
+  // verify that files are present on file system via terminal
+  for (const [directory, filename] of [
+    ['./', 'file-in-root.js'],
+    ['./first-level', 'file-in-first-level.js'],
+    ['./first-level/second-level', 'file-in-second-level.js'],
+  ]) {
+    await terminal.fill(`clear; ls ${directory}`);
+    await terminal.press('Enter');
+
+    await expect(terminalOutput).toContainText(filename, { useInnerText: true });
+  }
+});
+
+test('user can create folders', async ({ page }) => {
+  await page.goto(`${BASE_URL}/allow-edits-enabled`);
+  await expect(page.getByRole('heading', { level: 1, name: 'File Tree test - Allow Edits Enabled' })).toBeVisible();
+
+  // wait for terminal to start
+  const terminal = page.getByRole('textbox', { name: 'Terminal input' });
+  const terminalOutput = page.getByRole('tabpanel', { name: 'Terminal' });
+  await expect(terminalOutput).toContainText('~/tutorial', { useInnerText: true });
+
+  for (const [locator, folder] of [
+    [page.getByTestId('file-tree-root-context-menu'), 'folder-1'],
+    [page.getByRole('button', { name: 'folder-1' }), 'folder-2'],
+    [page.getByRole('button', { name: 'folder-2' }), 'folder-3'],
+  ] as const) {
+    await locator.click({ button: 'right' });
+    await page.getByRole('menuitem', { name: 'Create folder' }).click();
+
+    await page.locator('*:focus').fill(folder);
+    await page.locator('*:focus').press('Enter');
+    await expect(page.getByRole('button', { name: folder })).toBeVisible();
+  }
+
+  // verify that all folders are present on file tree after last creation
+  await expect(page.getByRole('button', { name: 'folder-1' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'folder-2' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'folder-3' })).toBeVisible();
+
+  // verify that files are present on file system via terminal
+  for (const [directory, folder] of [
+    ['./', 'folder-1'],
+    ['./folder-1', 'folder-2'],
+    ['./folder-1/folder-2', 'folder-3'],
+  ]) {
+    await terminal.fill(`clear; ls ${directory}`);
+    await terminal.press('Enter');
+
+    await expect(terminalOutput).toContainText(folder, { useInnerText: true });
+  }
+});

--- a/packages/astro/src/default/utils/content/default-localization.ts
+++ b/packages/astro/src/default/utils/content/default-localization.ts
@@ -7,10 +7,12 @@ export const DEFAULT_LOCALIZATION = {
   editPageText: 'Edit this page',
   webcontainerLinkText: 'Powered by WebContainers',
   filesTitleText: 'Files',
+  fileTreeCreateFileText: 'Create file',
+  fileTreeCreateFolderText: 'Create folder',
   prepareEnvironmentTitleText: 'Preparing Environment',
   defaultPreviewTitleText: 'Preview',
   reloadPreviewTitle: 'Reload Preview',
   toggleTerminalButtonText: 'Toggle Terminal',
   solveButtonText: 'Solve',
   resetButtonText: 'Reset',
-} satisfies Lesson['data']['i18n'];
+} satisfies Required<Lesson['data']['i18n']>;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -74,6 +74,7 @@
     "@lezer/lr": "^1.0.0",
     "@nanostores/react": "0.7.2",
     "@radix-ui/react-accordion": "^1.2.0",
+    "@radix-ui/react-context-menu": "^2.2.1",
     "@replit/codemirror-lang-svelte": "^6.0.0",
     "@tutorialkit/runtime": "workspace:*",
     "@tutorialkit/theme": "workspace:*",

--- a/packages/react/src/Panels/EditorPanel.tsx
+++ b/packages/react/src/Panels/EditorPanel.tsx
@@ -78,6 +78,7 @@ export function EditorPanel({
         </div>
         <FileTree
           className="flex-grow py-2 border-r border-tk-elements-app-borderColor text-sm"
+          i18n={i18n}
           selectedFile={selectedFile}
           hideRoot={hideRoot ?? true}
           files={files}

--- a/packages/react/src/Panels/EditorPanel.tsx
+++ b/packages/react/src/Panels/EditorPanel.tsx
@@ -1,5 +1,5 @@
 import type { I18n } from '@tutorialkit/types';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type ComponentProps } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle, type ImperativePanelHandle } from 'react-resizable-panels';
 import {
   CodeMirrorEditor,
@@ -29,6 +29,7 @@ interface Props {
   onEditorScroll?: OnEditorScroll;
   onHelpClick?: () => void;
   onFileSelect?: (value?: string) => void;
+  onFileTreeChange?: ComponentProps<typeof FileTree>['onFileChange'];
 }
 
 export function EditorPanel({
@@ -46,6 +47,7 @@ export function EditorPanel({
   onEditorScroll,
   onHelpClick,
   onFileSelect,
+  onFileTreeChange,
 }: Props) {
   const fileTreePanelRef = useRef<ImperativePanelHandle>(null);
 
@@ -81,6 +83,7 @@ export function EditorPanel({
           files={files}
           scope={fileTreeScope}
           onFileSelect={onFileSelect}
+          onFileChange={onFileTreeChange}
         />
       </Panel>
       <PanelResizeHandle

--- a/packages/react/src/Panels/EditorPanel.tsx
+++ b/packages/react/src/Panels/EditorPanel.tsx
@@ -17,7 +17,7 @@ const DEFAULT_FILE_TREE_SIZE = 25;
 interface Props {
   theme: Theme;
   id: unknown;
-  files: string[];
+  files: ComponentProps<typeof FileTree>['files'];
   i18n: I18n;
   hideRoot?: boolean;
   fileTreeScope?: string;

--- a/packages/react/src/Panels/WorkspacePanel.tsx
+++ b/packages/react/src/Panels/WorkspacePanel.tsx
@@ -1,7 +1,7 @@
 import { useStore } from '@nanostores/react';
 import { TutorialStore } from '@tutorialkit/runtime';
 import type { I18n } from '@tutorialkit/types';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ComponentProps } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle, type ImperativePanelHandle } from 'react-resizable-panels';
 import type { Theme } from '../core/types.js';
 import resizePanelStyles from '../styles/resize-panel.module.css';
@@ -11,6 +11,8 @@ import { PreviewPanel, type ImperativePreviewHandle } from './PreviewPanel.js';
 import { TerminalPanel } from './TerminalPanel.js';
 
 const DEFAULT_TERMINAL_SIZE = 25;
+
+type FileTreeChangeEvent = Parameters<NonNullable<ComponentProps<typeof EditorPanel>['onFileTreeChange']>>[0];
 
 interface Props {
   tutorialStore: TutorialStore;
@@ -119,6 +121,16 @@ function EditorSection({ theme, tutorialStore, hasEditor }: PanelProps) {
     }
   }
 
+  function onFileTreeChange({ method, type, value }: FileTreeChangeEvent) {
+    if (method == 'ADD' && type === 'FILE') {
+      return tutorialStore.addFile(value);
+    }
+
+    if (method == 'ADD' && type === 'FOLDER') {
+      return tutorialStore.addFolder(value);
+    }
+  }
+
   useEffect(() => {
     if (tutorialStore.hasSolution()) {
       setHelpAction('solve');
@@ -147,6 +159,7 @@ function EditorSection({ theme, tutorialStore, hasEditor }: PanelProps) {
         helpAction={helpAction}
         onHelpClick={lessonFullyLoaded ? onHelpClick : undefined}
         onFileSelect={(filePath) => tutorialStore.setSelectedFile(filePath)}
+        onFileTreeChange={onFileTreeChange}
         selectedFile={selectedFile}
         onEditorScroll={(position) => tutorialStore.setCurrentDocumentScrollPosition(position)}
         onEditorChange={(update) => tutorialStore.setCurrentDocumentContent(update.content)}

--- a/packages/react/src/Panels/WorkspacePanel.tsx
+++ b/packages/react/src/Panels/WorkspacePanel.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react';
-import { TutorialStore } from '@tutorialkit/runtime';
+import type { TutorialStore } from '@tutorialkit/runtime';
 import type { I18n } from '@tutorialkit/types';
 import { useCallback, useEffect, useRef, useState, type ComponentProps } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle, type ImperativePanelHandle } from 'react-resizable-panels';

--- a/packages/react/src/Panels/WorkspacePanel.tsx
+++ b/packages/react/src/Panels/WorkspacePanel.tsx
@@ -123,11 +123,11 @@ function EditorSection({ theme, tutorialStore, hasEditor }: PanelProps) {
   }
 
   function onFileTreeChange({ method, type, value }: FileTreeChangeEvent) {
-    if (method == 'ADD' && type === 'FILE') {
+    if (method === 'add' && type === 'file') {
       return tutorialStore.addFile(value);
     }
 
-    if (method == 'ADD' && type === 'FOLDER') {
+    if (method === 'add' && type === 'folder') {
       return tutorialStore.addFolder(value);
     }
   }

--- a/packages/react/src/Panels/WorkspacePanel.tsx
+++ b/packages/react/src/Panels/WorkspacePanel.tsx
@@ -97,6 +97,7 @@ function EditorSection({ theme, tutorialStore, hasEditor }: PanelProps) {
   const currentDocument = useStore(tutorialStore.currentDocument);
   const lessonFullyLoaded = useStore(tutorialStore.lessonFullyLoaded);
   const storeRef = useStore(tutorialStore.ref);
+  const files = useStore(tutorialStore.files);
 
   const lesson = tutorialStore.lesson!;
 
@@ -140,7 +141,7 @@ function EditorSection({ theme, tutorialStore, hasEditor }: PanelProps) {
         theme={theme}
         showFileTree={tutorialStore.hasFileTree()}
         editorDocument={currentDocument}
-        files={lesson.files[1]}
+        files={files}
         i18n={lesson.data.i18n as I18n}
         hideRoot={lesson.data.hideRoot}
         helpAction={helpAction}

--- a/packages/react/src/Panels/WorkspacePanel.tsx
+++ b/packages/react/src/Panels/WorkspacePanel.tsx
@@ -98,6 +98,7 @@ function EditorSection({ theme, tutorialStore, hasEditor }: PanelProps) {
   const selectedFile = useStore(tutorialStore.selectedFile);
   const currentDocument = useStore(tutorialStore.currentDocument);
   const lessonFullyLoaded = useStore(tutorialStore.lessonFullyLoaded);
+  const editorConfig = useStore(tutorialStore.editorConfig);
   const storeRef = useStore(tutorialStore.ref);
   const files = useStore(tutorialStore.files);
 
@@ -159,7 +160,7 @@ function EditorSection({ theme, tutorialStore, hasEditor }: PanelProps) {
         helpAction={helpAction}
         onHelpClick={lessonFullyLoaded ? onHelpClick : undefined}
         onFileSelect={(filePath) => tutorialStore.setSelectedFile(filePath)}
-        onFileTreeChange={onFileTreeChange}
+        onFileTreeChange={editorConfig.fileTree.allowEdits ? onFileTreeChange : undefined}
         selectedFile={selectedFile}
         onEditorScroll={(position) => tutorialStore.setCurrentDocumentScrollPosition(position)}
         onEditorChange={(update) => tutorialStore.setCurrentDocumentContent(update.content)}

--- a/packages/react/src/core/ContextMenu.tsx
+++ b/packages/react/src/core/ContextMenu.tsx
@@ -1,15 +1,15 @@
 import { useRef, useState, type ComponentProps } from 'react';
 import { Root, Portal, Content, Item, Trigger } from '@radix-ui/react-context-menu';
-import type { I18n } from '@tutorialkit/types';
+import type { FileDescriptor, I18n } from '@tutorialkit/types';
 
 interface FileChangeEvent {
-  type: 'FILE' | 'FOLDER';
-  method: 'ADD' | 'REMOVE' | 'RENAME';
+  type: FileDescriptor['type'];
+  method: 'add' | 'remove' | 'rename';
   value: string;
 }
 
 interface FileRenameEvent extends FileChangeEvent {
-  method: 'RENAME';
+  method: 'rename';
   oldValue: string;
 }
 
@@ -39,7 +39,7 @@ export function ContextMenu({
   triggerProps,
   ...props
 }: Props) {
-  const [state, setState] = useState<'IDLE' | 'ADD_FILE' | 'ADD_FOLDER'>('IDLE');
+  const [state, setState] = useState<'idle' | 'add_file' | 'add_folder'>('idle');
   const inputRef = useRef<HTMLInputElement>(null);
 
   if (!onFileChange) {
@@ -52,12 +52,12 @@ export function ContextMenu({
     if (name) {
       onFileChange?.({
         value: `${directory}/${name}`,
-        type: state === 'ADD_FILE' ? 'FILE' : 'FOLDER',
-        method: 'ADD',
+        type: state === 'add_file' ? 'file' : 'folder',
+        method: 'add',
       });
     }
 
-    setState('IDLE');
+    setState('idle');
   }
 
   function onFileNameKeyPress(event: React.KeyboardEvent<HTMLInputElement>) {
@@ -67,7 +67,7 @@ export function ContextMenu({
   }
 
   function onCloseAutoFocus(event: Event) {
-    if ((state === 'ADD_FILE' || state === 'ADD_FOLDER') && inputRef.current) {
+    if ((state === 'add_file' || state === 'add_folder') && inputRef.current) {
       event.preventDefault();
       inputRef.current.focus();
     }
@@ -83,9 +83,9 @@ export function ContextMenu({
     <Root>
       {position === 'before' && element}
 
-      {state !== 'IDLE' && (
+      {state !== 'idle' && (
         <div className="flex items-center gap-2 border-2 border-solid border-transparent" {...props}>
-          <div className={`scale-120 shrink-0 ${state === 'ADD_FILE' ? 'i-ph-file-duotone' : 'i-ph-folder-duotone'}`} />
+          <div className={`scale-120 shrink-0 ${state === 'add_file' ? 'i-ph-file-duotone' : 'i-ph-folder-duotone'}`} />
           <input
             ref={inputRef}
             autoFocus
@@ -104,11 +104,11 @@ export function ContextMenu({
           onCloseAutoFocus={onCloseAutoFocus}
           className="border border-tk-border-brighter b-rounded-md bg-tk-background-brighter py-2"
         >
-          <MenuItem icon="i-ph-file-plus" onClick={() => setState('ADD_FILE')}>
+          <MenuItem icon="i-ph-file-plus" onClick={() => setState('add_file')}>
             {i18n?.fileTreeCreateFileText || 'Create file'}
           </MenuItem>
 
-          <MenuItem icon="i-ph-folder-plus" onClick={() => setState('ADD_FOLDER')}>
+          <MenuItem icon="i-ph-folder-plus" onClick={() => setState('add_folder')}>
             {i18n?.fileTreeCreateFolderText || 'Create folder'}
           </MenuItem>
         </Content>

--- a/packages/react/src/core/ContextMenu.tsx
+++ b/packages/react/src/core/ContextMenu.tsx
@@ -1,0 +1,132 @@
+import { useRef, useState, type ComponentProps } from 'react';
+import { Root, Portal, Content, Item, Trigger } from '@radix-ui/react-context-menu';
+import type { I18n } from '@tutorialkit/types';
+
+interface FileChangeEvent {
+  type: 'FILE' | 'FOLDER';
+  method: 'ADD' | 'REMOVE' | 'RENAME';
+  value: string;
+}
+
+interface FileRenameEvent extends FileChangeEvent {
+  method: 'RENAME';
+  oldValue: string;
+}
+
+interface Props extends ComponentProps<'div'> {
+  /** Callback invoked when file is changed. */
+  onFileChange?: (event: FileChangeEvent | FileRenameEvent) => void;
+
+  /** Directory of the clicked file. */
+  directory: string;
+
+  /** Whether to render new files/directories before or after the trigger element. Defaults to `'before'`. */
+  position?: 'before' | 'after';
+
+  /** Localized texts for menu. */
+  i18n?: Pick<I18n, 'fileTreeCreateFileText' | 'fileTreeCreateFolderText'>;
+
+  /** Props for trigger wrapper. */
+  triggerProps?: ComponentProps<'div'> & { 'data-testid'?: string };
+}
+
+export function ContextMenu({
+  onFileChange,
+  directory,
+  i18n,
+  position = 'before',
+  children,
+  triggerProps,
+  ...props
+}: Props) {
+  const [state, setState] = useState<'IDLE' | 'ADD_FILE' | 'ADD_FOLDER'>('IDLE');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  if (!onFileChange) {
+    return children;
+  }
+
+  function onFileNameEnd(event: React.KeyboardEvent<HTMLInputElement> | React.FocusEvent<HTMLInputElement>) {
+    const name = event.currentTarget.value;
+    const isFile = state === 'ADD_FILE';
+
+    // files must contain extension
+    if (name && (!isFile || name.includes('.'))) {
+      onFileChange?.({
+        value: `${directory}/${name}`,
+        type: isFile ? 'FILE' : 'FOLDER',
+        method: 'ADD',
+      });
+    }
+
+    setState('IDLE');
+  }
+
+  function onFileNameKeyPress(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Enter' && event.currentTarget.value !== '') {
+      onFileNameEnd(event);
+    }
+  }
+
+  function onCloseAutoFocus(event: Event) {
+    if ((state === 'ADD_FILE' || state === 'ADD_FOLDER') && inputRef.current) {
+      event.preventDefault();
+      inputRef.current.focus();
+    }
+  }
+
+  const element = (
+    <Trigger asChild>
+      <div {...triggerProps}>{children}</div>
+    </Trigger>
+  );
+
+  return (
+    <Root>
+      {position === 'before' && element}
+
+      {state !== 'IDLE' && (
+        <div className="flex items-center gap-2 border-2 border-solid border-transparent" {...props}>
+          <div className={`scale-120 shrink-0 ${state === 'ADD_FILE' ? 'i-ph-file-duotone' : 'i-ph-folder-duotone'}`} />
+          <input
+            ref={inputRef}
+            autoFocus
+            type="text"
+            onBlur={onFileNameEnd}
+            onKeyUp={onFileNameKeyPress}
+            className="text-current bg-transparent w-20 outline-var(--tk-border-accent)"
+          />
+        </div>
+      )}
+
+      {position === 'after' && element}
+
+      <Portal>
+        <Content
+          onCloseAutoFocus={onCloseAutoFocus}
+          className="border border-tk-border-brighter b-rounded-md bg-tk-background-brighter py-2"
+        >
+          <MenuItem icon="i-ph-file-plus" onClick={() => setState('ADD_FILE')}>
+            {i18n?.fileTreeCreateFileText || 'Create file'}
+          </MenuItem>
+
+          <MenuItem icon="i-ph-folder-plus" onClick={() => setState('ADD_FOLDER')}>
+            {i18n?.fileTreeCreateFolderText || 'Create folder'}
+          </MenuItem>
+        </Content>
+      </Portal>
+    </Root>
+  );
+}
+
+function MenuItem({ icon, children, ...props }: { icon: string } & ComponentProps<typeof Item>) {
+  return (
+    <Item
+      {...props}
+      className="flex items-center gap-2 px-4 py-1 text-sm cursor-pointer ws-nowrap text-tk-elements-fileTree-folder-textColor hover:bg-tk-elements-fileTree-file-backgroundColorHover"
+    >
+      <span className={`${icon} scale-120 shrink-0`}></span>
+      <span>{children}</span>
+    </Item>
+  );
+}

--- a/packages/react/src/core/ContextMenu.tsx
+++ b/packages/react/src/core/ContextMenu.tsx
@@ -48,13 +48,11 @@ export function ContextMenu({
 
   function onFileNameEnd(event: React.KeyboardEvent<HTMLInputElement> | React.FocusEvent<HTMLInputElement>) {
     const name = event.currentTarget.value;
-    const isFile = state === 'ADD_FILE';
 
-    // files must contain extension
-    if (name && (!isFile || name.includes('.'))) {
+    if (name) {
       onFileChange?.({
         value: `${directory}/${name}`,
-        type: isFile ? 'FILE' : 'FOLDER',
+        type: state === 'ADD_FILE' ? 'FILE' : 'FOLDER',
         method: 'ADD',
       });
     }

--- a/packages/react/src/core/FileTree.spec.ts
+++ b/packages/react/src/core/FileTree.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from 'vitest';
+import type { FileDescriptor } from '@tutorialkit/types';
+import { sortFiles } from './FileTree.js';
+
+expect.addSnapshotSerializer({
+  serialize: (val) => `[${val.type}] ${val.path}`,
+  test: (val) => val?.type === 'file' || val?.type === 'folder',
+});
+
+test('initial files are sorted', () => {
+  const files: FileDescriptor[] = [
+    { path: 'test/math.test.ts', type: 'file' },
+    { path: '.gitignore', type: 'file' },
+    { path: 'src/math.ts', type: 'file' },
+    { path: 'src/geometry.ts', type: 'file' },
+  ];
+
+  files.sort(sortFiles);
+
+  expect(files).toMatchInlineSnapshot(`
+    [
+      [file] src/geometry.ts,
+      [file] src/math.ts,
+      [file] test/math.test.ts,
+      [file] .gitignore,
+    ]
+  `);
+});
+
+test('added files are sorted', () => {
+  const files: FileDescriptor[] = [
+    { path: 'test/math.test.ts', type: 'file' },
+    { path: '.gitignore', type: 'file' },
+    { path: 'src/math.ts', type: 'file' },
+
+    // added files at the end of the list
+    { path: 'something.ts', type: 'file' },
+    { path: 'another.css', type: 'file' },
+    { path: 'no-extension', type: 'file' },
+  ];
+
+  files.sort(sortFiles);
+
+  expect(files).toMatchInlineSnapshot(`
+    [
+      [file] src/math.ts,
+      [file] test/math.test.ts,
+      [file] .gitignore,
+      [file] another.css,
+      [file] no-extension,
+      [file] something.ts,
+    ]
+  `);
+});
+
+test('added folders are sorted', () => {
+  const files: FileDescriptor[] = [
+    { path: 'test/math.test.ts', type: 'file' },
+    { path: '.gitignore', type: 'file' },
+    { path: 'src/math.ts', type: 'file' },
+
+    // added files at the end of the list
+    { path: 'src/components', type: 'folder' },
+    { path: 'src/utils', type: 'folder' },
+    { path: 'test/unit', type: 'folder' },
+    { path: 'e2e', type: 'folder' },
+  ];
+
+  files.sort(sortFiles);
+
+  expect(files).toMatchInlineSnapshot(`
+    [
+      [folder] e2e,
+      [folder] src/components,
+      [folder] src/utils,
+      [file] src/math.ts,
+      [folder] test/unit,
+      [file] test/math.test.ts,
+      [file] .gitignore,
+    ]
+  `);
+});

--- a/packages/react/src/core/FileTree.tsx
+++ b/packages/react/src/core/FileTree.tsx
@@ -4,10 +4,17 @@ import { classNames } from '../utils/classnames.js';
 const NODE_PADDING_LEFT = 12;
 const DEFAULT_HIDDEN_FILES = [/\/node_modules\//];
 
+interface FileChangeEvent {
+  type: 'FILE' | 'FOLDER';
+  method: 'ADD' | 'REMOVE' | 'RENAME';
+  value: string;
+}
+
 interface Props {
   files: string[];
   selectedFile?: string;
   onFileSelect?: (filePath: string) => void;
+  onFileChange?: (event: FileChangeEvent) => void;
   hideRoot: boolean;
   scope?: string;
   hiddenFiles?: Array<string | RegExp>;

--- a/packages/react/src/core/FileTree.tsx
+++ b/packages/react/src/core/FileTree.tsx
@@ -86,7 +86,7 @@ export function FileTree({
   }
 
   return (
-    <div className={classNames(className, 'h-100% transition-theme bg-tk-elements-fileTree-backgroundColor')}>
+    <div className={classNames(className, 'h-full transition-theme bg-tk-elements-fileTree-backgroundColor')}>
       {filteredFileList.map((fileOrFolder) => {
         switch (fileOrFolder.kind) {
           case 'file': {
@@ -120,7 +120,7 @@ export function FileTree({
         style={getDepthStyle(0)}
         directory=""
         onFileChange={onFileChange}
-        triggerProps={{ className: 'h-100%', 'data-testid': 'file-tree-root-context-menu' }}
+        triggerProps={{ className: 'h-full', 'data-testid': 'file-tree-root-context-menu' }}
       />
     </div>
   );

--- a/packages/react/src/core/FileTree.tsx
+++ b/packages/react/src/core/FileTree.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type ComponentProps, type ReactNode } from 'react';
-import type { File } from '@tutorialkit/types';
+import type { FileDescriptor } from '@tutorialkit/types';
 import { ContextMenu } from './ContextMenu.js';
 import { classNames } from '../utils/classnames.js';
 
@@ -7,7 +7,7 @@ const NODE_PADDING_LEFT = 12;
 const DEFAULT_HIDDEN_FILES = [/\/node_modules\//];
 
 interface Props {
-  files: File[];
+  files: FileDescriptor[];
   selectedFile?: string;
   onFileSelect?: (filePath: string) => void;
   onFileChange?: ComponentProps<typeof ContextMenu>['onFileChange'];
@@ -90,7 +90,7 @@ export function FileTree({
     <div className={classNames(className, 'h-full transition-theme bg-tk-elements-fileTree-backgroundColor')}>
       {filteredFileList.map((fileOrFolder) => {
         switch (fileOrFolder.kind) {
-          case 'FILE': {
+          case 'file': {
             return (
               <File
                 key={fileOrFolder.id}
@@ -100,7 +100,7 @@ export function FileTree({
               />
             );
           }
-          case 'FOLDER': {
+          case 'folder': {
             return (
               <Folder
                 key={fileOrFolder.id}
@@ -216,19 +216,19 @@ interface BaseNode {
   depth: number;
   name: string;
   fullPath: string;
-  kind: File['type'];
+  kind: FileDescriptor['type'];
 }
 
 interface FileNode extends BaseNode {
-  kind: 'FILE';
+  kind: 'file';
 }
 
 interface FolderNode extends BaseNode {
-  kind: 'FOLDER';
+  kind: 'folder';
 }
 
 function buildFileList(
-  files: File[],
+  files: FileDescriptor[],
   hideRoot: boolean,
   scope: string | undefined,
   hiddenFiles: Array<string | RegExp>,
@@ -238,7 +238,7 @@ function buildFileList(
   const defaultDepth = hideRoot ? 0 : 1;
 
   if (!hideRoot) {
-    fileList.push({ kind: 'FOLDER', name: '/', fullPath: '/', depth: 0, id: 0 });
+    fileList.push({ kind: 'folder', name: '/', fullPath: '/', depth: 0, id: 0 });
   }
 
   for (const file of files) {
@@ -271,7 +271,7 @@ function buildFileList(
         folderPaths.add(fullPath);
 
         fileList.push({
-          kind: 'FOLDER',
+          kind: 'folder',
           id: fileList.length,
           name,
           fullPath,

--- a/packages/runtime/src/store/editor.spec.ts
+++ b/packages/runtime/src/store/editor.spec.ts
@@ -3,75 +3,6 @@ import { expect, test } from 'vitest';
 import { EditorStore } from './editor.js';
 import type { FileDescriptor } from '@tutorialkit/types';
 
-test('initial files are sorted', () => {
-  const store = new EditorStore();
-  store.setDocuments({
-    'test/math.test.ts': '',
-    '.gitignore': '',
-    'src/math.ts': '',
-    'src/geometry.ts': '',
-  });
-
-  expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
-    [
-      "src/geometry.ts",
-      "src/math.ts",
-      "test/math.test.ts",
-      ".gitignore",
-    ]
-  `);
-});
-
-test('added files are sorted', () => {
-  const store = new EditorStore();
-  store.setDocuments({
-    'test/math.test.ts': '',
-    '.gitignore': '',
-    'src/math.ts': '',
-  });
-
-  store.addFileOrFolder({ path: 'something.ts', type: 'file' });
-  store.addFileOrFolder({ path: 'another.css', type: 'file' });
-  store.addFileOrFolder({ path: 'no-extension', type: 'file' });
-
-  expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
-    [
-      "src/math.ts",
-      "test/math.test.ts",
-      ".gitignore",
-      "another.css",
-      "no-extension",
-      "something.ts",
-    ]
-  `);
-});
-
-test('added folders are sorted', () => {
-  const store = new EditorStore();
-  store.setDocuments({
-    'test/math.test.ts': '',
-    '.gitignore': '',
-    'src/math.ts': '',
-  });
-
-  store.addFileOrFolder({ path: 'src/components', type: 'folder' });
-  store.addFileOrFolder({ path: 'src/utils', type: 'folder' });
-  store.addFileOrFolder({ path: 'test/unit', type: 'folder' });
-  store.addFileOrFolder({ path: 'e2e', type: 'folder' });
-
-  expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
-    [
-      "e2e",
-      "src/components",
-      "src/utils",
-      "src/math.ts",
-      "test/unit",
-      "test/math.test.ts",
-      ".gitignore",
-    ]
-  `);
-});
-
 test('empty directories are removed when new content is added', () => {
   const store = new EditorStore();
   store.setDocuments({
@@ -82,8 +13,8 @@ test('empty directories are removed when new content is added', () => {
 
   expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
     [
-      "src/components",
       "src/index.ts",
+      "src/components",
     ]
   `);
 
@@ -91,8 +22,8 @@ test('empty directories are removed when new content is added', () => {
 
   expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
     [
-      "src/components/FileTree",
       "src/index.ts",
+      "src/components/FileTree",
     ]
   `);
 });

--- a/packages/runtime/src/store/editor.spec.ts
+++ b/packages/runtime/src/store/editor.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from 'vitest';
+
+import { EditorStore } from './editor.js';
+import type { File } from '@tutorialkit/types';
+
+test('initial files are sorted', () => {
+  const store = new EditorStore();
+  store.setDocuments({
+    'test/math.test.ts': '',
+    '.gitignore': '',
+    'src/math.ts': '',
+    'src/geometry.ts': '',
+  });
+
+  expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
+    [
+      "src/geometry.ts",
+      "src/math.ts",
+      "test/math.test.ts",
+      ".gitignore",
+    ]
+  `);
+});
+
+test('added files are sorted', () => {
+  const store = new EditorStore();
+  store.setDocuments({
+    'test/math.test.ts': '',
+    '.gitignore': '',
+    'src/math.ts': '',
+  });
+
+  store.addFileOrFolder({ path: 'something.ts', type: 'FILE' });
+  store.addFileOrFolder({ path: 'another.css', type: 'FILE' });
+  store.addFileOrFolder({ path: 'no-extension', type: 'FILE' });
+
+  expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
+    [
+      "src/math.ts",
+      "test/math.test.ts",
+      ".gitignore",
+      "another.css",
+      "no-extension",
+      "something.ts",
+    ]
+  `);
+});
+
+test('added folders are sorted', () => {
+  const store = new EditorStore();
+  store.setDocuments({
+    'test/math.test.ts': '',
+    '.gitignore': '',
+    'src/math.ts': '',
+  });
+
+  store.addFileOrFolder({ path: 'src/components', type: 'FOLDER' });
+  store.addFileOrFolder({ path: 'src/utils', type: 'FOLDER' });
+  store.addFileOrFolder({ path: 'test/unit', type: 'FOLDER' });
+  store.addFileOrFolder({ path: 'e2e', type: 'FOLDER' });
+
+  expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
+    [
+      "e2e",
+      "src/components",
+      "src/utils",
+      "src/math.ts",
+      "test/unit",
+      "test/math.test.ts",
+      ".gitignore",
+    ]
+  `);
+});
+
+test('empty directories are removed when new content is added', () => {
+  const store = new EditorStore();
+  store.setDocuments({
+    'src/index.ts': '',
+  });
+
+  store.addFileOrFolder({ path: 'src/components', type: 'FOLDER' });
+
+  expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
+    [
+      "src/components",
+      "src/index.ts",
+    ]
+  `);
+
+  store.addFileOrFolder({ path: 'src/components/FileTree', type: 'FOLDER' });
+
+  expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
+    [
+      "src/components/FileTree",
+      "src/index.ts",
+    ]
+  `);
+});
+
+function toFilename(file: File) {
+  return file.path;
+}

--- a/packages/runtime/src/store/editor.spec.ts
+++ b/packages/runtime/src/store/editor.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 
 import { EditorStore } from './editor.js';
-import type { File } from '@tutorialkit/types';
+import type { FileDescriptor } from '@tutorialkit/types';
 
 test('initial files are sorted', () => {
   const store = new EditorStore();
@@ -30,9 +30,9 @@ test('added files are sorted', () => {
     'src/math.ts': '',
   });
 
-  store.addFileOrFolder({ path: 'something.ts', type: 'FILE' });
-  store.addFileOrFolder({ path: 'another.css', type: 'FILE' });
-  store.addFileOrFolder({ path: 'no-extension', type: 'FILE' });
+  store.addFileOrFolder({ path: 'something.ts', type: 'file' });
+  store.addFileOrFolder({ path: 'another.css', type: 'file' });
+  store.addFileOrFolder({ path: 'no-extension', type: 'file' });
 
   expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
     [
@@ -54,10 +54,10 @@ test('added folders are sorted', () => {
     'src/math.ts': '',
   });
 
-  store.addFileOrFolder({ path: 'src/components', type: 'FOLDER' });
-  store.addFileOrFolder({ path: 'src/utils', type: 'FOLDER' });
-  store.addFileOrFolder({ path: 'test/unit', type: 'FOLDER' });
-  store.addFileOrFolder({ path: 'e2e', type: 'FOLDER' });
+  store.addFileOrFolder({ path: 'src/components', type: 'folder' });
+  store.addFileOrFolder({ path: 'src/utils', type: 'folder' });
+  store.addFileOrFolder({ path: 'test/unit', type: 'folder' });
+  store.addFileOrFolder({ path: 'e2e', type: 'folder' });
 
   expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
     [
@@ -78,7 +78,7 @@ test('empty directories are removed when new content is added', () => {
     'src/index.ts': '',
   });
 
-  store.addFileOrFolder({ path: 'src/components', type: 'FOLDER' });
+  store.addFileOrFolder({ path: 'src/components', type: 'folder' });
 
   expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
     [
@@ -87,7 +87,7 @@ test('empty directories are removed when new content is added', () => {
     ]
   `);
 
-  store.addFileOrFolder({ path: 'src/components/FileTree', type: 'FOLDER' });
+  store.addFileOrFolder({ path: 'src/components/FileTree', type: 'folder' });
 
   expect(store.files.get().map(toFilename)).toMatchInlineSnapshot(`
     [
@@ -97,6 +97,6 @@ test('empty directories are removed when new content is added', () => {
   `);
 });
 
-function toFilename(file: File) {
+function toFilename(file: FileDescriptor) {
   return file.path;
 }

--- a/packages/runtime/src/store/editor.ts
+++ b/packages/runtime/src/store/editor.ts
@@ -1,5 +1,6 @@
-import type { FilesRefList, Files } from '@tutorialkit/types';
+import type { FilesRefList, Files, EditorSchema } from '@tutorialkit/types';
 import { atom, map, computed } from 'nanostores';
+import { EditorConfig } from '../webcontainer/editor-config.js';
 
 export interface EditorDocument {
   value: string | Uint8Array;
@@ -16,6 +17,7 @@ export interface ScrollPosition {
 export type EditorDocuments = Record<string, EditorDocument | undefined>;
 
 export class EditorStore {
+  editorConfig = atom<EditorConfig>(new EditorConfig());
   selectedFile = atom<string | undefined>();
   documents = map<EditorDocuments>({});
 
@@ -27,6 +29,10 @@ export class EditorStore {
 
     return documents[selectedFile];
   });
+
+  setEditorConfig(config?: EditorSchema) {
+    this.editorConfig.set(new EditorConfig(config));
+  }
 
   setSelectedFile(filePath: string | undefined) {
     this.selectedFile.set(filePath);

--- a/packages/runtime/src/store/editor.ts
+++ b/packages/runtime/src/store/editor.ts
@@ -19,6 +19,7 @@ export class EditorStore {
   selectedFile = atom<string | undefined>();
   documents = map<EditorDocuments>({});
 
+  files = computed(this.documents, (documents) => Object.keys(documents).sort());
   currentDocument = computed([this.documents, this.selectedFile], (documents, selectedFile) => {
     if (!selectedFile) {
       return undefined;

--- a/packages/runtime/src/store/editor.ts
+++ b/packages/runtime/src/store/editor.ts
@@ -23,9 +23,7 @@ export class EditorStore {
   documents = map<EditorDocuments>({});
 
   files = computed(this.documents, (documents) =>
-    Object.entries(documents)
-      .map<FileDescriptor>(([path, doc]) => ({ path, type: doc?.type || 'file' }))
-      .sort(sortFiles),
+    Object.entries(documents).map<FileDescriptor>(([path, doc]) => ({ path, type: doc?.type || 'file' })),
   );
   currentDocument = computed([this.documents, this.selectedFile], (documents, selectedFile) => {
     if (!selectedFile) {
@@ -168,47 +166,4 @@ export class EditorStore {
       unsubscribeFromCurrentDocument();
     };
   }
-}
-
-function sortFiles(fileA: FileDescriptor, fileB: FileDescriptor) {
-  const segmentsA = fileA.path.split('/');
-  const segmentsB = fileB.path.split('/');
-  const minLength = Math.min(segmentsA.length, segmentsB.length);
-
-  for (let i = 0; i < minLength; i++) {
-    const a = toFileSegment(fileA, segmentsA, i);
-    const b = toFileSegment(fileB, segmentsB, i);
-
-    // folders are always shown before files
-    if (a.type !== b.type) {
-      return a.type === 'folder' ? -1 : 1;
-    }
-
-    const comparison = compareString(a.path, b.path);
-
-    // either folder name changed or last segments are compared
-    if (comparison !== 0 || a.isLast || b.isLast) {
-      return comparison;
-    }
-  }
-
-  return compareString(fileA.path, fileB.path);
-}
-
-function toFileSegment(file: FileDescriptor, segments: string[], current: number) {
-  const isLast = current + 1 === segments.length;
-
-  return { path: segments[current], type: isLast ? file.type : 'folder', isLast };
-}
-
-function compareString(a: string, b: string) {
-  if (a < b) {
-    return -1;
-  }
-
-  if (a > b) {
-    return 1;
-  }
-
-  return 0;
 }

--- a/packages/runtime/src/store/editor.ts
+++ b/packages/runtime/src/store/editor.ts
@@ -181,7 +181,7 @@ function sortFiles(fileA: FileDescriptor, fileB: FileDescriptor) {
 
     // folders are always shown before files
     if (a.type !== b.type) {
-      return a.type === 'FOLDER' ? -1 : 1;
+      return a.type === 'folder' ? -1 : 1;
     }
 
     const comparison = compareString(a.path, b.path);
@@ -198,7 +198,7 @@ function sortFiles(fileA: FileDescriptor, fileB: FileDescriptor) {
 function toFileSegment(file: FileDescriptor, segments: string[], current: number) {
   const isLast = current + 1 === segments.length;
 
-  return { path: segments[current], type: isLast ? file.type : 'FOLDER', isLast };
+  return { path: segments[current], type: isLast ? file.type : 'folder', isLast };
 }
 
 function compareString(a: string, b: string) {

--- a/packages/runtime/src/store/editor.ts
+++ b/packages/runtime/src/store/editor.ts
@@ -1,4 +1,4 @@
-import type { FilesRefList, Files, EditorSchema, File } from '@tutorialkit/types';
+import type { FilesRefList, Files, EditorSchema, FileDescriptor } from '@tutorialkit/types';
 import { atom, map, computed } from 'nanostores';
 import { EditorConfig } from '../webcontainer/editor-config.js';
 
@@ -6,7 +6,7 @@ export interface EditorDocument {
   value: string | Uint8Array;
   loading: boolean;
   filePath: string;
-  type: File['type'];
+  type: FileDescriptor['type'];
   scroll?: ScrollPosition;
 }
 
@@ -24,7 +24,7 @@ export class EditorStore {
 
   files = computed(this.documents, (documents) =>
     Object.entries(documents)
-      .map<File>(([path, doc]) => ({ path, type: doc?.type || 'FILE' }))
+      .map<FileDescriptor>(([path, doc]) => ({ path, type: doc?.type || 'file' }))
       .sort(sortFiles),
   );
   currentDocument = computed([this.documents, this.selectedFile], (documents, selectedFile) => {
@@ -45,7 +45,7 @@ export class EditorStore {
 
   setDocuments(files: FilesRefList | Files) {
     // lesson, solution and template file entries are always files  - empty folders are not supported
-    const type = 'FILE';
+    const type = 'file';
 
     // check if it is a FilesRef
     if (Array.isArray(files)) {
@@ -99,11 +99,11 @@ export class EditorStore {
     });
   }
 
-  addFileOrFolder(file: File) {
+  addFileOrFolder(file: FileDescriptor) {
     // when adding file or folder to empty folder, remove the empty folder from documents
-    const emptyFolder = this.files.get().find((f) => f.type === 'FOLDER' && file.path.startsWith(f.path));
+    const emptyFolder = this.files.get().find((f) => f.type === 'folder' && file.path.startsWith(f.path));
 
-    if (emptyFolder && emptyFolder.type === 'FOLDER') {
+    if (emptyFolder && emptyFolder.type === 'folder') {
       this.documents.setKey(emptyFolder.path, undefined);
     }
 
@@ -170,7 +170,7 @@ export class EditorStore {
   }
 }
 
-function sortFiles(fileA: File, fileB: File) {
+function sortFiles(fileA: FileDescriptor, fileB: FileDescriptor) {
   const segmentsA = fileA.path.split('/');
   const segmentsB = fileB.path.split('/');
   const minLength = Math.min(segmentsA.length, segmentsB.length);
@@ -192,11 +192,11 @@ function sortFiles(fileA: File, fileB: File) {
     }
   }
 
-  throw new Error(JSON.stringify({ fileA, fileB }));
+  return compareString(fileA.path, fileB.path);
 }
 
-function toFileSegment(file: File, segments: string[], current: number) {
-  const isLast = segments[current + 1] === undefined;
+function toFileSegment(file: FileDescriptor, segments: string[], current: number) {
+  const isLast = current + 1 === segments.length;
 
   return { path: segments[current], type: isLast ? file.type : 'FOLDER', isLast };
 }

--- a/packages/runtime/src/store/editor.ts
+++ b/packages/runtime/src/store/editor.ts
@@ -13,7 +13,7 @@ export interface ScrollPosition {
   left: number;
 }
 
-export type EditorDocuments = Record<string, EditorDocument>;
+export type EditorDocuments = Record<string, EditorDocument | undefined>;
 
 export class EditorStore {
   selectedFile = atom<string | undefined>();
@@ -80,6 +80,21 @@ export class EditorStore {
     this.documents.setKey(filePath, {
       ...documentState,
       scroll: position,
+    });
+  }
+
+  addFileOrFolder(filePath: string) {
+    // when adding file to empty folder, remove the empty folder from documents
+    const emptyFolder = this.files.value?.find((path) => filePath.startsWith(path));
+
+    if (emptyFolder) {
+      this.documents.setKey(emptyFolder, undefined);
+    }
+
+    this.documents.setKey(filePath, {
+      filePath,
+      value: '',
+      loading: false,
     });
   }
 

--- a/packages/runtime/src/store/index.ts
+++ b/packages/runtime/src/store/index.ts
@@ -207,6 +207,10 @@ export class TutorialStore {
     return this._editorStore.documents;
   }
 
+  get files(): ReadableAtom<string[]> {
+    return this._editorStore.files;
+  }
+
   get template(): Files | undefined {
     return this._lessonTemplate;
   }

--- a/packages/runtime/src/store/index.ts
+++ b/packages/runtime/src/store/index.ts
@@ -308,6 +308,27 @@ export class TutorialStore {
     this._editorStore.setSelectedFile(filePath);
   }
 
+  addFile(filePath: string) {
+    // prevent creating duplicates
+    if (this._editorStore.files.get().includes(filePath)) {
+      return this.setSelectedFile(filePath);
+    }
+
+    this._editorStore.addFileOrFolder(filePath);
+    this.setSelectedFile(filePath);
+    this._runner.updateFile(filePath, '');
+  }
+
+  addFolder(folderPath: string) {
+    // prevent creating duplicates
+    if (this._editorStore.files.get().some((file) => file.startsWith(folderPath))) {
+      return;
+    }
+
+    this._editorStore.addFileOrFolder(folderPath);
+    this._runner.createFolder(folderPath);
+  }
+
   updateFile(filePath: string, content: string) {
     const hasChanged = this._editorStore.updateFile(filePath, content);
 

--- a/packages/runtime/src/store/index.ts
+++ b/packages/runtime/src/store/index.ts
@@ -1,4 +1,4 @@
-import type { Files, Lesson } from '@tutorialkit/types';
+import type { File, Files, Lesson } from '@tutorialkit/types';
 import type { WebContainer } from '@webcontainer/api';
 import { atom, type ReadableAtom } from 'nanostores';
 import { LessonFilesFetcher } from '../lesson-files.js';
@@ -213,7 +213,7 @@ export class TutorialStore {
     return this._editorStore.documents;
   }
 
-  get files(): ReadableAtom<string[]> {
+  get files(): ReadableAtom<File[]> {
     return this._editorStore.files;
   }
 
@@ -315,21 +315,21 @@ export class TutorialStore {
     this.setSelectedFile(filePath);
 
     // prevent creating duplicates
-    if (this._editorStore.files.get().includes(filePath)) {
+    if (this._editorStore.files.get().find((file) => file.type === 'FILE' && file.path === filePath)) {
       return;
     }
 
-    this._editorStore.addFileOrFolder(filePath);
+    this._editorStore.addFileOrFolder({ path: filePath, type: 'FILE' });
     this._runner.updateFile(filePath, '');
   }
 
   addFolder(folderPath: string) {
     // prevent creating duplicates
-    if (this._editorStore.files.get().some((file) => file.startsWith(folderPath))) {
+    if (this._editorStore.files.get().some((file) => file.path.startsWith(folderPath))) {
       return;
     }
 
-    this._editorStore.addFileOrFolder(folderPath);
+    this._editorStore.addFileOrFolder({ path: folderPath, type: 'FOLDER' });
     this._runner.createFolder(folderPath);
   }
 

--- a/packages/runtime/src/store/index.ts
+++ b/packages/runtime/src/store/index.ts
@@ -8,6 +8,7 @@ import type { ITerminal } from '../utils/terminal.js';
 import { bootStatus, unblockBoot, type BootStatus } from '../webcontainer/on-demand-boot.js';
 import type { PreviewInfo } from '../webcontainer/preview-info.js';
 import { StepsController } from '../webcontainer/steps.js';
+import type { EditorConfig } from '../webcontainer/editor-config.js';
 import type { TerminalConfig } from '../webcontainer/terminal-config.js';
 import { EditorStore, type EditorDocument, type EditorDocuments, type ScrollPosition } from './editor.js';
 import { PreviewsStore } from './previews.js';
@@ -141,6 +142,7 @@ export class TutorialStore {
 
     this._previewsStore.setPreviews(lesson.data.previews ?? true);
     this._terminalStore.setTerminalConfiguration(lesson.data.terminal);
+    this._editorStore.setEditorConfig(lesson.data.editor);
     this._runner.setCommands(lesson.data);
     this._editorStore.setDocuments(lesson.files);
 
@@ -195,6 +197,10 @@ export class TutorialStore {
     return this._terminalStore.terminalConfig;
   }
 
+  get editorConfig(): ReadableAtom<EditorConfig> {
+    return this._editorStore.editorConfig;
+  }
+
   get currentDocument(): ReadableAtom<EditorDocument | undefined> {
     return this._editorStore.currentDocument;
   }
@@ -243,9 +249,7 @@ export class TutorialStore {
       return false;
     }
 
-    const { editor } = this._lesson.data;
-
-    return editor === undefined || editor === true || (editor !== false && editor?.fileTree !== false);
+    return this.editorConfig.get().fileTree.visible;
   }
 
   hasEditor(): boolean {
@@ -253,9 +257,7 @@ export class TutorialStore {
       return false;
     }
 
-    const { editor } = this._lesson.data;
-
-    return editor !== false;
+    return this.editorConfig.get().visible;
   }
 
   hasPreviews(): boolean {

--- a/packages/runtime/src/store/index.ts
+++ b/packages/runtime/src/store/index.ts
@@ -1,4 +1,4 @@
-import type { File, Files, Lesson } from '@tutorialkit/types';
+import type { FileDescriptor, Files, Lesson } from '@tutorialkit/types';
 import type { WebContainer } from '@webcontainer/api';
 import { atom, type ReadableAtom } from 'nanostores';
 import { LessonFilesFetcher } from '../lesson-files.js';
@@ -213,7 +213,7 @@ export class TutorialStore {
     return this._editorStore.documents;
   }
 
-  get files(): ReadableAtom<File[]> {
+  get files(): ReadableAtom<FileDescriptor[]> {
     return this._editorStore.files;
   }
 
@@ -315,11 +315,11 @@ export class TutorialStore {
     this.setSelectedFile(filePath);
 
     // prevent creating duplicates
-    if (this._editorStore.files.get().find((file) => file.type === 'FILE' && file.path === filePath)) {
+    if (this._editorStore.files.get().find((file) => file.path === filePath)) {
       return;
     }
 
-    this._editorStore.addFileOrFolder({ path: filePath, type: 'FILE' });
+    this._editorStore.addFileOrFolder({ path: filePath, type: 'file' });
     this._runner.updateFile(filePath, '');
   }
 
@@ -329,7 +329,7 @@ export class TutorialStore {
       return;
     }
 
-    this._editorStore.addFileOrFolder({ path: folderPath, type: 'FOLDER' });
+    this._editorStore.addFileOrFolder({ path: folderPath, type: 'folder' });
     this._runner.createFolder(folderPath);
   }
 

--- a/packages/runtime/src/store/index.ts
+++ b/packages/runtime/src/store/index.ts
@@ -311,13 +311,15 @@ export class TutorialStore {
   }
 
   addFile(filePath: string) {
+    // always select the existing or newly created file
+    this.setSelectedFile(filePath);
+
     // prevent creating duplicates
     if (this._editorStore.files.get().includes(filePath)) {
-      return this.setSelectedFile(filePath);
+      return;
     }
 
     this._editorStore.addFileOrFolder(filePath);
-    this.setSelectedFile(filePath);
     this._runner.updateFile(filePath, '');
   }
 

--- a/packages/runtime/src/tutorial-runner.ts
+++ b/packages/runtime/src/tutorial-runner.ts
@@ -98,6 +98,23 @@ export class TutorialRunner {
     this._currentCommandProcess?.resize({ cols, rows });
   }
 
+  createFolder(folderPath: string): void {
+    const previousLoadPromise = this._currentLoadTask?.promise;
+
+    this._currentLoadTask = newTask(
+      async (signal) => {
+        await previousLoadPromise;
+
+        const webcontainer = await this._webcontainer;
+
+        signal.throwIfAborted();
+
+        await webcontainer.fs.mkdir(folderPath);
+      },
+      { ignoreCancel: true },
+    );
+  }
+
   /**
    * Update the content of a single file in WebContainer.
    *

--- a/packages/runtime/src/webcontainer/editor-config.ts
+++ b/packages/runtime/src/webcontainer/editor-config.ts
@@ -1,0 +1,70 @@
+import type { EditorSchema } from '@tutorialkit/types';
+
+interface NormalizedEditorConfig {
+  /** Visibility of editor */
+  visible: boolean;
+
+  fileTree: {
+    /** Visibility of file tree */
+    visible: boolean;
+
+    /** Whether to allow file and folder editing in file tree */
+    allowEdits: boolean;
+  };
+}
+
+export class EditorConfig {
+  private _config: NormalizedEditorConfig;
+
+  constructor(config?: EditorSchema) {
+    this._config = normalizeEditorConfig(config);
+  }
+
+  get visible() {
+    return this._config.visible;
+  }
+
+  get fileTree() {
+    return this._config.fileTree;
+  }
+}
+
+function normalizeEditorConfig(config?: EditorSchema): NormalizedEditorConfig {
+  if (config === false) {
+    return {
+      visible: false,
+      fileTree: {
+        visible: false,
+        allowEdits: false,
+      },
+    };
+  }
+
+  if (config === undefined || config === true) {
+    return {
+      visible: true,
+      fileTree: {
+        visible: true,
+        allowEdits: false,
+      },
+    };
+  }
+
+  if (typeof config.fileTree === 'boolean') {
+    return {
+      visible: true,
+      fileTree: {
+        visible: config.fileTree,
+        allowEdits: false,
+      },
+    };
+  }
+
+  return {
+    visible: true,
+    fileTree: {
+      visible: true,
+      allowEdits: config.fileTree?.allowEdits || false,
+    },
+  };
+}

--- a/packages/template/src/content/tutorial/1-basics/1-introduction/2-foo/content.mdx
+++ b/packages/template/src/content/tutorial/1-basics/1-introduction/2-foo/content.mdx
@@ -8,6 +8,9 @@ previews:
   - [1, 'Test Runner']
   - '2/some/custom/pathname'
   - '2/another/pathname'
+editor:
+  fileTree:
+    allowEdits: true
 terminal:
   panels: 'terminal'
 editPageLink: 'https://tutorialkit.dev'

--- a/packages/types/src/entities/index.ts
+++ b/packages/types/src/entities/index.ts
@@ -3,7 +3,7 @@ import type { ChapterSchema, LessonSchema, PartSchema } from '../schemas/index.j
 
 export type * from './nav.js';
 
-export type File = { path: string; type: 'FILE' | 'FOLDER' };
+export type FileDescriptor = { path: string; type: 'file' | 'folder' };
 export type Files = Record<string, string | Uint8Array>;
 
 /**

--- a/packages/types/src/entities/index.ts
+++ b/packages/types/src/entities/index.ts
@@ -3,6 +3,7 @@ import type { ChapterSchema, LessonSchema, PartSchema } from '../schemas/index.j
 
 export type * from './nav.js';
 
+export type File = { path: string; type: 'FILE' | 'FOLDER' };
 export type Files = Record<string, string | Uint8Array>;
 
 /**

--- a/packages/types/src/schemas/common.ts
+++ b/packages/types/src/schemas/common.ts
@@ -161,8 +161,32 @@ export const terminalSchema = z.union([
   }),
 ]);
 
+export const editorSchema = z.union([
+  // can either be completely removed by setting it to `false`
+  z.boolean().optional(),
+
+  z.strictObject({
+    fileTree: z
+      .union([
+        // or you can only remove the file tree
+        z.boolean(),
+
+        // or configure file tree with options
+        z.strictObject({
+          allowEdits: z
+            .boolean()
+            .describe(
+              'Allow file tree’s items to be edited by right clicking them. Supports file and folder creation.',
+            ),
+        }),
+      ])
+      .optional(),
+  }),
+]);
+
 export type TerminalPanelType = z.infer<typeof panelTypeSchema>;
 export type TerminalSchema = z.infer<typeof terminalSchema>;
+export type EditorSchema = z.infer<typeof editorSchema>;
 
 export const webcontainerSchema = commandsSchema.extend({
   previews: previewSchema
@@ -191,18 +215,10 @@ export const webcontainerSchema = commandsSchema.extend({
     .string()
     .optional()
     .describe('Defines which file should be opened in the code editor by default when lesson loads.'),
-  editor: z
-    .union([
-      // can either be completely removed by setting it to `false`
-      z.boolean().optional(),
-
-      // or you can only remove the file tree
-      z.strictObject({
-        fileTree: z.boolean().optional(),
-      }),
-    ])
+  editor: editorSchema
+    .optional()
     .describe(
-      'Configure whether or not the editor should be rendered. If an object is provided with fileTree: false, only the file tree is hidden.',
+      'Configure whether or not the editor should be rendered. File tree can be configured by proving an object with fileTree option.',
     ),
   i18n: i18nSchema
     .optional()

--- a/packages/types/src/schemas/i18n.ts
+++ b/packages/types/src/schemas/i18n.ts
@@ -53,6 +53,26 @@ export const i18nSchema = z.object({
   filesTitleText: z.string().optional().describe('Text shown on top of the file tree.'),
 
   /**
+   * Text shown on file tree's context menu's file creation button.
+   *
+   * @default 'Create file'
+   */
+  fileTreeCreateFileText: z
+    .string()
+    .optional()
+    .describe("Text shown on file tree's context menu's file creation button."),
+
+  /**
+   * Text shown on file tree's context menu's folder creation button.
+   *
+   * @default 'Create folder'
+   */
+  fileTreeCreateFolderText: z
+    .string()
+    .optional()
+    .describe("Text shown on file tree's context menu's folder creation button."),
+
+  /**
    * Text shown on top of the steps section.
    *
    * @default 'Preparing Environment'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,9 @@ importers:
       '@radix-ui/react-accordion':
         specifier: ^1.2.0
         version: 1.2.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-context-menu':
+        specifier: ^2.2.1
+        version: 2.2.1(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
       '@replit/codemirror-lang-svelte':
         specifier: ^6.0.0
         version: 6.0.0(@codemirror/autocomplete@6.16.3)(@codemirror/lang-css@6.2.1)(@codemirror/lang-html@6.4.9)(@codemirror/lang-javascript@6.2.2)(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.1)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.17)(@lezer/lr@1.4.1)
@@ -2344,6 +2347,34 @@ packages:
     dependencies:
       '@expressive-code/core': 0.35.3
 
+  /@floating-ui/core@1.6.7:
+    resolution: {integrity: sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==}
+    dependencies:
+      '@floating-ui/utils': 0.2.7
+    dev: false
+
+  /@floating-ui/dom@1.6.10:
+    resolution: {integrity: sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==}
+    dependencies:
+      '@floating-ui/core': 1.6.7
+      '@floating-ui/utils': 0.2.7
+    dev: false
+
+  /@floating-ui/react-dom@2.1.1(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/dom': 1.6.10
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
+  /@floating-ui/utils@0.2.7:
+    resolution: {integrity: sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==}
+    dev: false
+
   /@humanwhocodes/module-importer@1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
@@ -2803,6 +2834,25 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
+  /@radix-ui/react-arrow@1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@types/react': 18.3.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /@radix-ui/react-collapsible@1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-zQY7Epa8sTL0mq4ajSJpjgn2YmCgyrG7RsQgLp3C0LQVkG7+Tf6Pv1CeNWZLyqMjhdPkBa5Lx7wYBeSu7uCSTA==}
     peerDependencies:
@@ -2864,6 +2914,30 @@ packages:
       react: 18.3.1
     dev: false
 
+  /@radix-ui/react-context-menu@2.2.1(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-wvMKKIeb3eOrkJ96s722vcidZ+2ZNfcYZWBPRHIB1VWrF+fiF851Io6LX0kmK5wTDQFKdulCCKJk2c3SBaQHvA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.1(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /@radix-ui/react-context@1.1.0(@types/react@18.3.3)(react@18.3.1):
     resolution: {integrity: sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==}
     peerDependencies:
@@ -2890,6 +2964,63 @@ packages:
       react: 18.3.1
     dev: false
 
+  /@radix-ui/react-dismissable-layer@1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
+  /@radix-ui/react-focus-guards@1.1.0(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.3.3
+      react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-focus-scope@1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /@radix-ui/react-id@1.1.0(@types/react@18.3.3)(react@18.3.1):
     resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
     peerDependencies:
@@ -2902,6 +3033,90 @@ packages:
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
       '@types/react': 18.3.3
       react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-menu@2.1.1(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-oa3mXRRVjHi6DZu/ghuzdylyjaMXLymx83irM7hTxutQbD+7IhPKdMdRHD26Rm+kHRrWcrUkkRPv5pd47a2xFQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.1(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.7(@types/react@18.3.3)(react@18.3.1)
+    dev: false
+
+  /@radix-ui/react-popper@1.2.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@floating-ui/react-dom': 2.1.1(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/rect': 1.1.0
+      '@types/react': 18.3.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
+  /@radix-ui/react-portal@1.1.1(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     dev: false
 
   /@radix-ui/react-presence@1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
@@ -2938,6 +3153,33 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/react-slot': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
+  /@radix-ui/react-roving-focus@1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react@18.3.3)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.3)(react@18.3.1)
       '@types/react': 18.3.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -2984,6 +3226,20 @@ packages:
       react: 18.3.1
     dev: false
 
+  /@radix-ui/react-use-escape-keydown@1.1.0(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
+      react: 18.3.1
+    dev: false
+
   /@radix-ui/react-use-layout-effect@1.1.0(@types/react@18.3.3)(react@18.3.1):
     resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
     peerDependencies:
@@ -2995,6 +3251,38 @@ packages:
     dependencies:
       '@types/react': 18.3.3
       react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-use-rect@1.1.0(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/rect': 1.1.0
+      '@types/react': 18.3.3
+      react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-use-size@1.1.0(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@types/react': 18.3.3
+      react: 18.3.1
+    dev: false
+
+  /@radix-ui/rect@1.1.0:
+    resolution: {integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==}
     dev: false
 
   /@replit/codemirror-lang-svelte@6.0.0(@codemirror/autocomplete@6.16.3)(@codemirror/lang-css@6.2.1)(@codemirror/lang-html@6.4.9)(@codemirror/lang-javascript@6.2.2)(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.28.1)(@lezer/common@1.2.1)(@lezer/highlight@1.2.0)(@lezer/javascript@1.4.17)(@lezer/lr@1.4.1):
@@ -3311,6 +3599,27 @@ packages:
       - supports-color
       - typescript
     dev: true
+
+  /@tutorialkit/cli@0.2.2:
+    resolution: {integrity: sha512-ZsBFHdjO/XbbXme+tkQu9UU7G9qiHVLKUQp2abt9prxennZdPkIBR3Y3gdYnYdezaWQ+8k19xrx6152pnPruIQ==}
+    engines: {node: '>=18.18.0'}
+    hasBin: true
+    dependencies:
+      '@babel/generator': 7.24.5
+      '@babel/parser': 7.24.5
+      '@babel/traverse': 7.24.5
+      '@babel/types': 7.24.5
+      '@clack/prompts': 0.7.0
+      chalk: 5.3.0
+      detect-indent: 7.0.1
+      execa: 9.2.0
+      ignore: 5.3.1
+      lookpath: 1.2.2
+      which-pm: 2.2.0
+      yargs-parser: 21.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@types/acorn@4.0.6:
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
@@ -4171,6 +4480,13 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  /aria-hidden@1.2.4:
+    resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
+    engines: {node: '>=10'}
+    dependencies:
+      tslib: 2.6.3
+    dev: false
 
   /aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -5165,6 +5481,10 @@ packages:
     engines: {node: '>=8'}
     requiresBuild: true
 
+  /detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+    dev: false
+
   /deterministic-object-hash@2.0.2:
     resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
     engines: {node: '>=18'}
@@ -5823,6 +6143,11 @@ packages:
   /get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
+  /get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
+    dev: false
+
   /get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -6271,6 +6596,12 @@ packages:
 
   /inline-style-parser@0.2.3:
     resolution: {integrity: sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g==}
+
+  /invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false
 
   /is-absolute-url@4.0.1:
     resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
@@ -7826,6 +8157,41 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
+  /react-remove-scroll-bar@2.3.6(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.3.3
+      react: 18.3.1
+      react-style-singleton: 2.2.1(@types/react@18.3.3)(react@18.3.1)
+      tslib: 2.6.3
+    dev: false
+
+  /react-remove-scroll@2.5.7(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.3.3
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.6(@types/react@18.3.3)(react@18.3.1)
+      react-style-singleton: 2.2.1(@types/react@18.3.3)(react@18.3.1)
+      tslib: 2.6.3
+      use-callback-ref: 1.3.2(@types/react@18.3.3)(react@18.3.1)
+      use-sidecar: 1.1.2(@types/react@18.3.3)(react@18.3.1)
+    dev: false
+
   /react-resizable-panels@2.0.19(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-v3E41kfKSuCPIvJVb4nL4mIZjjKIn/gh6YqZF/gDfQDolv/8XnhJBek4EiV2gOr3hhc5A3kOGOayk3DhanpaQw==}
     peerDependencies:
@@ -7834,6 +8200,23 @@ packages:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
+  /react-style-singleton@2.2.1(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.3.3
+      get-nonce: 1.0.1
+      invariant: 2.2.4
+      react: 18.3.1
+      tslib: 2.6.3
     dev: false
 
   /react@18.3.1:
@@ -8996,6 +9379,37 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.1
+
+  /use-callback-ref@1.3.2(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.3.3
+      react: 18.3.1
+      tslib: 2.6.3
+    dev: false
+
+  /use-sidecar@1.1.2(@types/react@18.3.3)(react@18.3.1):
+    resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.3.3
+      detect-node-es: 1.1.0
+      react: 18.3.1
+      tslib: 2.6.3
+    dev: false
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}


### PR DESCRIPTION
- Closes https://github.com/stackblitz/tutorialkit/issues/263
- Related to https://github.com/stackblitz/tutorialkit/discussions/204
- Not related to https://github.com/stackblitz/tutorialkit/issues/208. That one requires WebContainer changes so that we can listen for fs changes.
- While working on the `FileTree` I noticed plenty of issues with it and created https://github.com/stackblitz/tutorialkit/issues/326 as follow-up. 

### BREAKING CHANGES

- Projects that are using `@tutorialkit/react` package directly, **without TutorialKit** need to update `<FileTree>` component's `props.files` type

### Description

Adds new metadata option that can be used to enable file and folder creation in the file tree. By default this feature is disabled.

```yaml
---
type: lesson
editor:
  fileTree:
    allowEdits: true
---
```

[tk-filetree-example.webm](https://github.com/user-attachments/assets/d9a664ee-1af6-4cf4-9f20-addbaa3fb381)

