### PR TITLE
docs: `TopBar` override to mention `open-in-stackblitz-link` slot

### DIFF
--- a/docs/tutorialkit.dev/astro.config.ts
+++ b/docs/tutorialkit.dev/astro.config.ts
@@ -13,6 +13,11 @@ export default defineConfig({
       'Cross-Origin-Opener-Policy': 'same-origin',
     },
   },
+  vite: {
+    ssr: {
+      noExternal: '@tutorialkit/react',
+    },
+  },
   integrations: [
     react(),
     UnoCSS(),

--- a/docs/tutorialkit.dev/src/content/docs/guides/overriding-components.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/guides/overriding-components.mdx
@@ -44,6 +44,7 @@ tutorialkit({
 When overriding `TopBar` you can place TutorialKit's default components using following [Astro slots](https://docs.astro.build/en/basics/astro-components/#named-slots):
 
 - `logo`: Logo of the application
+- `open-in-stackblitz-link`: Link for opening current lesson in StackBlitz
 - `theme-switch`:  Switch for changing the theme
 - `login-button`: For StackBlitz Enterprise user, the login button
 
@@ -58,6 +59,8 @@ When overriding `TopBar` you can place TutorialKit's default components using fo
   <slot name="theme-switch" />
 
   <LanguageSelect />
+
+  <slot name="open-in-stackblitz-link" />
 
   <slot name="login-button" />
 </nav>


### PR DESCRIPTION
- Add missing documentation for https://github.com/stackblitz/tutorialkit/pull/112