### PR TITLE
chore(eslint): ignore .vscode-test folder

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@ export default [
       '**/dist',
       '**/node_modules',
       '**/.astro/**',
+      '**/.vscode-test/**',
 
       // we ignore our demo templates because they may contain code that is formatted specifically for the demo
       'docs/demo/src/templates',


### PR DESCRIPTION
This PR makes sure we ignore the `.vscode-test` folder. 

If one start working on the VSCode TutorialKit extension, they will get that folder and our current `pnpm lint` script won't ignore it, causing it to take forever to run.