### PR TITLE
feat: sync files from WebContainer to editor

### DIFF
--- a/packages/astro/src/default/utils/content.ts
+++ b/packages/astro/src/default/utils/content.ts
@@ -248,6 +248,7 @@ export async function getTutorial(): Promise<Tutorial> {
           'i18n',
           'editPageLink',
           'openInStackBlitz',
+          'filesystem',
         ],
       ),
     };

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -4,10 +4,9 @@ A wrapper around the **[WebContainer API][webcontainer-api]** focused on providi
 
 The runtime exposes the following:
 
-- `lessonFilesFetcher`: A singleton that lets you fetch the contents of the lesson files
-- `TutorialRunner`: The API to manage your tutorial content in WebContainer
+- `TutorialStore`: A store to manage your tutorial content in WebContainer and in your components.
 
-Only a single instance of `TutorialRunner` should be created in your application and its lifetime is bound by the lifetime of the WebContainer instance.
+Only a single instance of `TutorialStore` should be created in your application and its lifetime is bound by the lifetime of the WebContainer instance.
 
 ## License
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,3 @@
-export { LessonFilesFetcher } from './lesson-files.js';
-export { TutorialRunner } from './tutorial-runner.js';
 export type { Command, Commands, PreviewInfo, Step, Steps } from './webcontainer/index.js';
 export { safeBoot } from './webcontainer/index.js';
 export { TutorialStore } from './store/index.js';

--- a/packages/runtime/src/store/editor.ts
+++ b/packages/runtime/src/store/editor.ts
@@ -113,7 +113,7 @@ export class EditorStore {
     });
   }
 
-  updateFile(filePath: string, content: string): boolean {
+  updateFile(filePath: string, content: string | Uint8Array): boolean {
     const documentState = this.documents.get()[filePath];
 
     if (!documentState) {

--- a/packages/runtime/src/store/index.ts
+++ b/packages/runtime/src/store/index.ts
@@ -3,7 +3,7 @@ import type { WebContainer } from '@webcontainer/api';
 import { atom, type ReadableAtom } from 'nanostores';
 import { LessonFilesFetcher } from '../lesson-files.js';
 import { newTask, type Task } from '../tasks.js';
-import { TutorialRunner } from '../tutorial-runner.js';
+import { TutorialRunner } from './tutorial-runner.js';
 import type { ITerminal } from '../utils/terminal.js';
 import { bootStatus, unblockBoot, type BootStatus } from '../webcontainer/on-demand-boot.js';
 import type { PreviewInfo } from '../webcontainer/preview-info.js';
@@ -59,7 +59,7 @@ export class TutorialStore {
     this._lessonFilesFetcher = new LessonFilesFetcher(basePathname);
     this._previewsStore = new PreviewsStore(this._webcontainer);
     this._terminalStore = new TerminalStore(this._webcontainer, useAuth);
-    this._runner = new TutorialRunner(this._webcontainer, this._terminalStore, this._stepController);
+    this._runner = new TutorialRunner(this._webcontainer, this._terminalStore, this._editorStore, this._stepController);
 
     /**
      * By having this code under `import.meta.hot`, it gets:
@@ -149,6 +149,8 @@ export class TutorialStore {
     if (options.ssr) {
       return;
     }
+
+    this._runner.setSyncChangesFromWebContainer(lesson.data.filesystem?.syncChanges ?? false);
 
     this._lessonTask = newTask(
       async (signal) => {

--- a/packages/runtime/src/store/tutorial-runner.spec.ts
+++ b/packages/runtime/src/store/tutorial-runner.spec.ts
@@ -4,10 +4,10 @@ import { resetProcessFactory, setProcessFactory } from '@tutorialkit/test-utils'
 import { WebContainer } from '@webcontainer/api';
 import type { MockedWebContainer } from '@tutorialkit/test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { TerminalStore } from './store/terminal.js';
+import { TerminalStore } from './terminal.js';
 import { TutorialRunner } from './tutorial-runner.js';
-import { withResolvers } from './utils/promises.js';
-import { StepsController } from './webcontainer/steps.js';
+import { withResolvers } from '../utils/promises.js';
+import { StepsController } from '../webcontainer/steps.js';
 
 beforeEach(() => {
   resetProcessFactory();

--- a/packages/runtime/src/store/tutorial-runner.ts
+++ b/packages/runtime/src/store/tutorial-runner.ts
@@ -1,11 +1,13 @@
 import type { CommandsSchema, Files } from '@tutorialkit/types';
-import type { WebContainer, WebContainerProcess } from '@webcontainer/api';
-import type { TerminalStore } from './store/terminal.js';
-import { newTask, type Task, type TaskCancelled } from './tasks.js';
-import { clearTerminal, escapeCodes, type ITerminal } from './utils/terminal.js';
-import { Command, Commands } from './webcontainer/command.js';
-import { StepsController } from './webcontainer/steps.js';
-import { diffFiles, toFileTree } from './webcontainer/utils/files.js';
+import type { WebContainer, WebContainerProcess, IFSWatcher } from '@webcontainer/api';
+import type { TerminalStore } from './terminal.js';
+import { newTask, type Task, type TaskCancelled } from '../tasks.js';
+import { clearTerminal, escapeCodes, type ITerminal } from '../utils/terminal.js';
+import { Command, Commands } from '../webcontainer/command.js';
+import { StepsController } from '../webcontainer/steps.js';
+import { diffFiles, toFileTree } from '../webcontainer/utils/files.js';
+import type { EditorStore } from './editor.js';
+import { MultiCounter } from '../utils/multi-counter.js';
 
 interface LoadFilesOptions {
   /**
@@ -60,6 +62,12 @@ export class TutorialRunner {
   private _currentTemplate: Files | undefined = undefined;
   private _currentFiles: Files | undefined = undefined;
   private _currentRunCommands: Commands | undefined = undefined;
+
+  private _ignoreFileEvents = new MultiCounter();
+  private _watcher: IFSWatcher | undefined;
+  private _syncContentFromWebContainer = false;
+  private _readyToWatch = false;
+
   private _packageJsonDirty = false;
   private _commandsChanged = false;
 
@@ -70,8 +78,19 @@ export class TutorialRunner {
   constructor(
     private _webcontainer: Promise<WebContainer>,
     private _terminalStore: TerminalStore,
+    private _editorStore: EditorStore,
     private _stepController: StepsController,
   ) {}
+
+  setSyncChangesFromWebContainer(value: boolean) {
+    this._syncContentFromWebContainer = value;
+
+    if (this._readyToWatch && this._syncContentFromWebContainer) {
+      this._webcontainer.then((webcontainer) => this._setupWatcher(webcontainer));
+    } else if (!this._syncContentFromWebContainer) {
+      this._stopWatcher();
+    }
+  }
 
   /**
    * Set the commands to run. This updates the reported `steps` if any have changed.
@@ -109,6 +128,8 @@ export class TutorialRunner {
 
         signal.throwIfAborted();
 
+        this._ignoreFileEvents.increment(folderPath);
+
         await webcontainer.fs.mkdir(folderPath);
       },
       { ignoreCancel: true },
@@ -131,6 +152,8 @@ export class TutorialRunner {
         const webcontainer = await this._webcontainer;
 
         signal.throwIfAborted();
+
+        this._ignoreFileEvents.increment(filePath);
 
         await webcontainer.fs.writeFile(filePath, content);
 
@@ -155,6 +178,8 @@ export class TutorialRunner {
         const webcontainer = await this._webcontainer;
 
         signal.throwIfAborted();
+
+        this._ignoreFileEvents.increment(Object.keys(files));
 
         await webcontainer.mount(toFileTree(files));
 
@@ -184,6 +209,12 @@ export class TutorialRunner {
     this._currentLoadTask = newTask(
       async (signal) => {
         await previousLoadPromise;
+
+        // no watcher should be installed
+        this._readyToWatch = false;
+
+        // stop current watcher if they are any
+        this._stopWatcher();
 
         const webcontainer = await this._webcontainer;
 
@@ -375,7 +406,7 @@ export class TutorialRunner {
     const abortListener = () => this._currentCommandProcess?.kill();
     signal.addEventListener('abort', abortListener, { once: true });
 
-    const hasMainCommand = !!commands.mainCommand;
+    let shouldClearDirtyFlag = true;
 
     try {
       const commandList = [...commands];
@@ -419,6 +450,9 @@ export class TutorialRunner {
         }
 
         if (isMainCommand) {
+          shouldClearDirtyFlag = false;
+
+          this._setupWatcher(webcontainer);
           this._clearDirtyState();
         }
 
@@ -431,6 +465,13 @@ export class TutorialRunner {
           });
 
           this._stepController.skipRemaining(index + 1);
+
+          /**
+           * We don't clear the dirty flag in that case as there was an error and re-running all commands
+           * is the probably better than not running anything.
+           */
+          shouldClearDirtyFlag = false;
+
           break;
         } else {
           this._stepController.updateStep(index, {
@@ -447,9 +488,17 @@ export class TutorialRunner {
         }
       }
 
-      if (!hasMainCommand) {
+      /**
+       * All commands were run but we didn't clear the dirty state.
+       * We have to, otherwise we would re-run those commands when moving
+       * to a lesson that has the exact same set of commands.
+       */
+      if (shouldClearDirtyFlag) {
         this._clearDirtyState();
       }
+
+      // make sure the watcher is configured
+      this._setupWatcher(webcontainer);
     } finally {
       signal.removeEventListener('abort', abortListener);
     }
@@ -501,6 +550,77 @@ export class TutorialRunner {
     }
 
     this._updateDirtyState(files);
+  }
+
+  private _stopWatcher(): void {
+    // if there was a watcher terminate it
+    if (this._watcher) {
+      this._watcher.close();
+      this._watcher = undefined;
+    }
+  }
+
+  private _setupWatcher(webcontainer: WebContainer) {
+    // inform that the watcher could be installed if we wanted to
+    this._readyToWatch = true;
+
+    // if the watcher is alreay setup or we don't sync content we exit
+    if (this._watcher || !this._syncContentFromWebContainer) {
+      return;
+    }
+
+    const filesToRead = new Map<string, 'utf-8' | null>();
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const readFiles = () => {
+      const files = [...filesToRead.entries()];
+
+      filesToRead.clear();
+
+      Promise.all(
+        files.map(async ([filePath, encoding]) => {
+          // casts could be removed with an `if` but it feels weird
+          const content = (await webcontainer.fs.readFile(filePath, encoding as any)) as Uint8Array | string;
+
+          return [filePath, content] as const;
+        }),
+      ).then((fileContents) => {
+        for (const [filePath, content] of fileContents) {
+          this._editorStore.updateFile(filePath, content);
+        }
+      });
+    };
+
+    const scheduleReadFor = (filePath: string, encoding: 'utf-8' | null) => {
+      filesToRead.set(filePath, encoding);
+
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(readFiles, 100);
+    };
+
+    this._watcher = webcontainer.fs.watch('.', { recursive: true }, (eventType, filename) => {
+      const filePath = `/${filename}`;
+
+      // events we should ignore because we caused them in the TutorialRunner
+      if (!this._ignoreFileEvents.decrement(filePath)) {
+        return;
+      }
+
+      // for now we only care about 'change' event
+      if (eventType !== 'change') {
+        return;
+      }
+
+      // we ignore all paths that aren't exposed in the `_editorStore`
+      const file = this._editorStore.documents.get()[filePath];
+
+      if (!file) {
+        return;
+      }
+
+      scheduleReadFor(filePath, typeof file.value === 'string' ? 'utf-8' : null);
+    });
   }
 
   private _clearDirtyState() {

--- a/packages/runtime/src/utils/multi-counter.ts
+++ b/packages/runtime/src/utils/multi-counter.ts
@@ -1,0 +1,27 @@
+export class MultiCounter {
+  private _counts = new Map<string, number>();
+
+  increment(name: string | string[]) {
+    if (typeof name === 'string') {
+      const currentValue = this._counts.get(name) ?? 0;
+
+      this._counts.set(name, currentValue + 1);
+
+      return;
+    }
+
+    name.forEach((value) => this.increment(value));
+  }
+
+  decrement(name: string): boolean {
+    const currentValue = this._counts.get(name) ?? 0;
+
+    if (currentValue === 0) {
+      return true;
+    }
+
+    this._counts.set(name, currentValue - 1);
+
+    return currentValue - 1 === 0;
+  }
+}

--- a/packages/runtime/src/utils/promises.ts
+++ b/packages/runtime/src/utils/promises.ts
@@ -28,7 +28,7 @@ export function wait(ms: number): Promise<void> {
  * @returns A promise that resolves after the tick.
  */
 export function tick() {
-  return new Promise((resolve) => {
+  return new Promise<void>((resolve) => {
     setTimeout(resolve);
   });
 }

--- a/packages/template/src/content/tutorial/1-basics/meta.md
+++ b/packages/template/src/content/tutorial/1-basics/meta.md
@@ -1,4 +1,6 @@
 ---
 type: part
 title: Basics
+filesystem:
+  syncChanges: true
 ---

--- a/packages/types/src/schemas/common.ts
+++ b/packages/types/src/schemas/common.ts
@@ -55,6 +55,15 @@ export const previewSchema = z.union([
 
 export type PreviewSchema = z.infer<typeof previewSchema>;
 
+export const fileSystemSchema = z.object({
+  syncChanges: z
+    .boolean()
+    .optional()
+    .describe('When set to true, when a file is changed in WebContainer, it is updated in the editor as well.'),
+});
+
+export type FileSystemSchema = z.infer<typeof fileSystemSchema>;
+
 const panelTypeSchema = z
   .union([z.literal('output'), z.literal('terminal')])
   .describe(`The type of the terminal which can either be 'output' or 'terminal'.`);
@@ -199,6 +208,11 @@ export const webcontainerSchema = commandsSchema.extend({
     .optional()
     .describe(
       'Navigating to a lesson that specifies autoReload will always reload the preview. This is typically only needed if your server does not support HMR.',
+    ),
+  filesystem: fileSystemSchema
+    .optional()
+    .describe(
+      'Configure how changes happening on the filesystem should impact the Tutorial. For instance, when new files are being changed, whether those change should be reflected in the editor.',
     ),
   template: z
     .string()


### PR DESCRIPTION
This PR adds a new property `filesystem` to the metadata of a Tutorial / Chapter / Lesson:

```yaml
filesystem:
  syncChanges: true # default to false
```

When `syncChanges` is set to `true`, if files are modified on WebContainer via a terminal or by a process spawned manually via the `webcontainer` export on `tutorialkit:core`, the changes will be reflected in the editor.

Closes #208

This is opt-in because it can have a performance impact on the UI if lots of files are being modified / generated.

In the future we will likely accept `boolean | string` for `syncChanges` to be able to narrow down the watched files and improve performance.