### PR TITLE
fix: prevent overwriting template files via `<FileTree>`

### DIFF
--- a/docs/tutorialkit.dev/src/components/react-examples/ExampleFileTree.tsx
+++ b/docs/tutorialkit.dev/src/components/react-examples/ExampleFileTree.tsx
@@ -13,7 +13,7 @@ export default function ExampleFileTree() {
       hiddenFiles={['package-lock.json']}
       selectedFile={selectedFile}
       onFileSelect={setSelectedFile}
-      onFileChange={(event) => {
+      onFileChange={async (event) => {
         if (event.method === 'add') {
           setFiles([...files, { path: event.value, type: event.type }]);
         }

--- a/docs/tutorialkit.dev/src/content/docs/reference/configuration.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/reference/configuration.mdx
@@ -103,14 +103,28 @@ type I18nText = {
    *
    * @default 'This action is not allowed'
    */
-  fileTreeActionNotAllowed?: string,
+  fileTreeActionNotAllowedText?: string,
 
   /**
-   * Text shown on dialog describing allowed patterns when file or folder createion failed.
+   * Text shown on dialog when user attempts create file or folder that already exists on filesystem but is not visible on file tree, e.g. template files.
+   *
+   * @default 'File exists on filesystem already'
+   */
+  fileTreeFileExistsAlreadyText?: string,
+
+  /**
+   * Text shown on dialog describing allowed patterns when file or folder creation failed.
    *
    * @default 'Created files and folders must match following patterns:'
    */
   fileTreeAllowedPatternsText?: string,
+
+  /**
+   * Text shown on confirmation buttons on dialogs.
+   *
+   * @default 'OK'
+   */
+  confirmationText?: string,
 
   /**
    * Text shown on top of the steps section.

--- a/docs/tutorialkit.dev/src/content/docs/reference/react-components.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/reference/react-components.mdx
@@ -107,13 +107,15 @@ A component to list files in a tree view.
 
 * `onFileSelect: (file: string) => void` - A callback that will be called when a file is clicked. The path of the file that was clicked will be passed as an argument.
 
-* `onFileChange: (event: FileChangeEvent) => void` - An optional callback that will be called when a new file or folder is created from the file tree's context menu. When callback is not passed, file tree does not allow adding new files.
+* `onFileChange: (event: FileChangeEvent) => Promise<void>` - An optional callback that will be called when a new file or folder is created from the file tree's context menu. This callback should throw errors with `FilesystemError` messages.
   ```ts
   interface FileChangeEvent {
     type: 'file' | 'folder';
     method: 'add' | 'remove' | 'rename';
     value: string;
   }
+
+  type FilesystemError = 'FILE_EXISTS' | 'FOLDER_EXISTS';
   ```
 
 * `allowEditPatterns?: string[]` - Glob patterns for paths that allow editing files and folders. Disabled by default.

--- a/e2e/src/templates/default/file-on-template.js
+++ b/e2e/src/templates/default/file-on-template.js
@@ -1,0 +1,1 @@
+export default 'This file is present on template';

--- a/e2e/src/templates/file-server/index.mjs
+++ b/e2e/src/templates/file-server/index.mjs
@@ -1,5 +1,5 @@
-import http from 'node:http';
 import fs from 'node:fs';
+import http from 'node:http';
 
 const server = http.createServer((req, res) => {
   if (req.url === '/' || req.url === '/index.html') {

--- a/packages/react/src/Panels/WorkspacePanel.tsx
+++ b/packages/react/src/Panels/WorkspacePanel.tsx
@@ -122,7 +122,7 @@ function EditorSection({ theme, tutorialStore, hasEditor }: PanelProps) {
     }
   }
 
-  function onFileTreeChange({ method, type, value }: FileTreeChangeEvent) {
+  async function onFileTreeChange({ method, type, value }: FileTreeChangeEvent) {
     if (method === 'add' && type === 'file') {
       return tutorialStore.addFile(value);
     }

--- a/packages/react/src/core/ContextMenu.tsx
+++ b/packages/react/src/core/ContextMenu.tsx
@@ -200,7 +200,7 @@ function Dialog({
         <RadixDialog.Overlay className="fixed inset-0 opacity-50 bg-black" />
 
         <RadixDialog.Content className="fixed top-50% left-50% transform-translate--50% w-90vw max-w-450px max-h-85vh rounded-xl text-tk-text-primary bg-tk-background-primary">
-          <div className="relative py-4 px-10">
+          <div className="relative p-10">
             <RadixDialog.Title className="text-6">{title}</RadixDialog.Title>
 
             <div className="my-4">{children}</div>

--- a/packages/runtime/src/store/tutorial-runner.ts
+++ b/packages/runtime/src/store/tutorial-runner.ts
@@ -189,6 +189,62 @@ export class TutorialRunner {
     );
   }
 
+  async fileExists(filepath: string) {
+    const previousLoadPromise = this._currentLoadTask?.promise;
+
+    return new Promise<boolean>((resolve, reject) => {
+      this._currentLoadTask = newTask(
+        async (signal) => {
+          await previousLoadPromise;
+
+          const webcontainer = await this._webcontainer;
+
+          if (signal.aborted) {
+            reject(new Error('Task was aborted'));
+          }
+
+          signal.throwIfAborted();
+
+          try {
+            await webcontainer.fs.readFile(filepath);
+            resolve(true);
+          } catch {
+            resolve(false);
+          }
+        },
+        { ignoreCancel: true },
+      );
+    });
+  }
+
+  async folderExists(folderPath: string) {
+    const previousLoadPromise = this._currentLoadTask?.promise;
+
+    return new Promise<boolean>((resolve, reject) => {
+      this._currentLoadTask = newTask(
+        async (signal) => {
+          await previousLoadPromise;
+
+          const webcontainer = await this._webcontainer;
+
+          if (signal.aborted) {
+            reject(new Error('Task was aborted'));
+          }
+
+          signal.throwIfAborted();
+
+          try {
+            await webcontainer.fs.readdir(folderPath);
+            resolve(true);
+          } catch {
+            resolve(false);
+          }
+        },
+        { ignoreCancel: true },
+      );
+    });
+  }
+
   /**
    * Load the provided files into WebContainer and remove any other files that had been loaded previously.
    *

--- a/packages/types/src/default-localization.ts
+++ b/packages/types/src/default-localization.ts
@@ -10,6 +10,7 @@ export const DEFAULT_LOCALIZATION = {
   fileTreeCreateFileText: 'Create file',
   fileTreeCreateFolderText: 'Create folder',
   fileTreeActionNotAllowedText: 'This action is not allowed',
+  fileTreeFileExistsAlreadyText: 'File exists on filesystem already',
   fileTreeAllowedPatternsText: 'Created files and folders must match following patterns:',
   confirmationText: 'OK',
   prepareEnvironmentTitleText: 'Preparing Environment',

--- a/packages/types/src/entities/index.ts
+++ b/packages/types/src/entities/index.ts
@@ -6,6 +6,8 @@ export type * from './nav.js';
 export type FileDescriptor = { path: string; type: 'file' | 'folder' };
 export type Files = Record<string, string | Uint8Array>;
 
+export type FilesystemError = 'FILE_EXISTS' | 'FOLDER_EXISTS';
+
 /**
  * This tuple contains a "ref" which points to a file to fetch with the `LessonFilesFetcher` and
  * the list of file paths included by that ref.

--- a/packages/types/src/schemas/i18n.ts
+++ b/packages/types/src/schemas/i18n.ts
@@ -83,6 +83,18 @@ export const i18nSchema = z.object({
     .describe("Text shown on dialog when user attempts to edit files that don't match allowed patterns."),
 
   /**
+   * Text shown on dialog when user attempts create file or folder that already exists on filesystem but is not visible on file tree, e.g. template files.
+   *
+   * @default 'File exists on filesystem already'
+   */
+  fileTreeFileExistsAlreadyText: z
+    .string()
+    .optional()
+    .describe(
+      'Text shown on dialog when user attempts create file or folder that already exists on filesystem but is not visible on file tree, e.g. template files.',
+    ),
+
+  /**
    * Text shown on dialog describing allowed patterns when file or folder creation failed.
    *
    * @default 'Created files and folders must match following patterns:'


### PR DESCRIPTION
Show an error if user tries to create file that already exists on file system, but is not visible on FileTree. Such files are for example non-lesson template files.

<img src="https://github.com/user-attachments/assets/8d284f0a-4af6-4db0-8942-388a183ccf16" width="480" />
