### PR TITLE
chore: release TutorialKit vscode extension v0.1.2

### DIFF
--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "tutorialkit" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.1.2]
+
+- Prevent running extension on non-TutorialKit projects (#242)
+
 ## [0.1.1]
 
 All the following changes are for the Tutorial Panel:

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -4,7 +4,7 @@
   "description": "TutorialKit support in VS Code",
   "icon": "resources/tutorialkit-icon.png",
   "publisher": "StackBlitz",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "engines": {
     "vscode": "^1.80.0"
   },


### PR DESCRIPTION
- Prepare extension for 0.1.2 release. 
- Closes #337 
