### PR TITLE
feat!: mark `@tutorialkit/react` component API as experimental feature

### DIFF
--- a/docs/tutorialkit.dev/src/content/docs/reference/react-components.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/reference/react-components.mdx
@@ -22,6 +22,13 @@ import sourceUseWebcontainer from "@components/react-examples/hooks/useWebcontai
 
 You can reuse TutorialKit's React components in your own applications. They are designed to work well with the [WebContainer API][webcontainers].
 
+:::note
+Using `@tutorialkit/react` package directly without `@tutorialkit/astro` is **experimental** at the moment.
+This package may introduce breaking changes in patch and minor version updates. Pay extra attention when updating the versions.
+
+We are planning to stabilize component API of `@tutorialkit/react` in future.
+:::
+
 Here's a simple editor that can be made with those components:
 
 <ExampleSimpleEditor client:load />


### PR DESCRIPTION
- Marks direct usage of `@tutorialkit/react` as experimental feature
- This does not affect users of TutorialKit. This affects only users who are using `@tutorialkit/react` without TutorialKit itself

The components of `@tutorialkit/react` are exposed as public API but we don't have any test cases for these components. We only have e2e tests through `@tutorialkit/astro`. When ever we implement new features to `@tutorialkit/astro`, we need to pay extra attention not to introduce any new required component props, or modify any existing ones to avoid semver breaking changes. Breaking the API is too easy at the moment and not easily visible from the code. 

Now that we are still in v0.x.x version, let's mark `@tutorialkit/react` API as experimental. This allows us to keep breaking the API when needed. Once we get more test cases and see that implementing new features doesn't require breaking the API anymore, let's remove the experimental status. 