### PR TITLE
feat(runtime): add `terminal.input` for writing to stdin

### DIFF
--- a/packages/runtime/src/utils/terminal.ts
+++ b/packages/runtime/src/utils/terminal.ts
@@ -4,6 +4,7 @@ export interface ITerminal {
 
   reset: () => void;
   write: (data: string) => void;
+  input: (data: string) => void;
   onData: (cb: (data: string) => void) => void;
 }
 


### PR DESCRIPTION
- During https://github.com/stackblitz/tutorialkit/pull/348 it was noticed that `terminal.write` cannot be used to write into terminal's stdin. It's only useful for writing to stdout.
- Adds new terminal method that can be used to write commands to stdin. The #348 will add proper example into documentation.

```tsx
import tutorialStore from 'tutorialkit:store';

export default function Example() {
  async function onClick() {
    const terminal = tutorialStore.terminalConfig.value!.panels[0];
    terminal.input('npm run test\n');
  }

  return (
    <button
      onClick={onClick}
      className="px-4 py-1 my-3 cursor-pointer border-1 border-tk-border-primary rounded-md bg-tk-elements-primaryButton-backgroundColor text-tk-elements-primaryButton-textColor"
    >
      Run tests
    </button>
  );
}
```
