### PR TITLE
Fix toggle terminal visibility

### DIFF
--- a/packages/runtime/src/lesson-files.spec.ts
+++ b/packages/runtime/src/lesson-files.spec.ts
@@ -1,3 +1,4 @@
+// where is global?
 import { describe, test, expect, beforeAll, vi, afterAll, beforeEach } from 'vitest';
 import { LessonFilesFetcher } from './lesson-files.js';
 

--- a/packages/runtime/src/store/terminal.ts
+++ b/packages/runtime/src/store/terminal.ts
@@ -27,6 +27,13 @@ export class TerminalStore {
   }
 
   hasTerminalPanel() {
+   // This condition checks if the 'metadata' object exists and whether the 'terminal' property within the metadata is explicitly set to 'false'.
+// If the 'terminal' property is false, it returns 'false', which likely disables or hides the terminal in the user interface.
+// However, if the 'metadata' object itself or the 'terminal' property is undefined or true, this condition is bypassed, and the terminal remains enabled.
+
+    /*if(this.metadata && this.metadata.terminal === false) {
+      return false;
+    }*/
     return this.terminalConfig.get().panels.length > 0;
   }
 

--- a/packages/types/src/schemas/part.ts
+++ b/packages/types/src/schemas/part.ts
@@ -16,3 +16,22 @@ export const partSchema = baseSchema.extend({
 });
 
 export type PartSchema = z.infer<typeof partSchema>;
+
+// This schema defines the structure of a "part" in the tutorial.
+// The `type` is fixed as 'part', applying only to parts.
+// `chapters` is an optional array to list chapters, ordered by folder if not provided.
+// The `terminal` flag controls terminal visibility: `false` hides it, defaults to `true` (visible).
+/*export const partSchema = baseSchema.extend({
+  type: z.literal('part'),
+  chapters: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'The list of chapters in this part. The order of this array defines the order of the chapters. If not specified a folder-based numbering system is used instead.',
+    ),
+  terminal: z
+    .boolean()
+    .optional()
+    .describe('Controls whether the terminal is visible for this part. Defaults to true.'),
+});
+*/

--- a/packages/types/src/schemas/part.ts
+++ b/packages/types/src/schemas/part.ts
@@ -9,6 +9,10 @@ export const partSchema = baseSchema.extend({
     .describe(
       'The list of chapters in this part. The order of this array defines the order of the chapters. If not specified a folder-based numbering system is used instead.',
     ),
+  terminal: z
+    .boolean()
+    .optional()
+    .describe('Controls whether the terminal is visible for this part. Defaults to true.'),
 });
 
 export type PartSchema = z.infer<typeof partSchema>;


### PR DESCRIPTION
Description of What Happened:
In my open-source contribution, I aimed to fix a bug where the "Toggle Terminal" button stayed visible even when the terminal was set to be hidden in the metadata. After investigating, I realized that key parts of the metadata handling function were missing from the repository I pulled from.

I added a terminal property to the part schema as a boolean flag to address this. This flag controls whether the terminal should be shown or hidden for each tutorial part. While I couldn't fully verify the solution due to missing parts in the repository, I contributed this schema change as a potential fix to help manage terminal visibility.

Additions Made:

Added terminal property to the part schema to control terminal visibility for each part.
Introduced logic based on this flag to toggle the terminal visibility in the interface.

All added components have been commented out with a full description of functionality and purpose