### PR TITLE
feat(terminal): restrict default allowed commands to 'ls' and 'echo'

### DIFF
--- a/docs/tutorialkit.dev/src/content/docs/reference/configuration.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/reference/configuration.mdx
@@ -312,7 +312,7 @@ You can set terminal open by default by specifying the `open` value.
 
 An interactive terminal will disable the output redirect syntax by default. For instance, you cannot create a file `world.txt` with the contents `hello` using the command `echo hello > world.txt`. The reason is that this could disrupt the lesson if a user overwrites certain files. To allow output redirection, you can change the behavior with the `allowRedirects` setting. You can define this setting either per panel or for all panels at once.
 
-Additionally, you may not want users to run arbitrary commands. For example, if you are creating a lesson about `vitest`, you could specify that the only command the user can run is `vitest` by providing a list of `allowCommands`. Any other command executed by the user will be blocked. You can define the `allowCommands` setting either per panel or for all panels at once.
+Additionally, you may not want users to run arbitrary commands. For example, if you are creating a lesson about vitest, you could specify that the only command the user can run is vitest by providing a list of allowCommands. By default, the allowed commands are ls and echo. Providing a list of allowCommands will override these defaults, and specifying an empty list will allow all commands. Any other command executed by the user will be blocked. You can define the allowCommands setting either per panel or for all panels at once.
 
 By default, in every new lesson terminals start a new session. If you want to keep the terminal session between lessons, you can specify the `id` property for a given terminal panel and keep the same `id` across lessons.
 <PropertyTable inherited type="Terminal" />

--- a/packages/runtime/src/webcontainer/terminal-config.ts
+++ b/packages/runtime/src/webcontainer/terminal-config.ts
@@ -200,6 +200,9 @@ export class TerminalPanel implements ITerminal {
   }
 }
 
+// set the default commands for the terminal
+const DEFAULT_COMMANDS = ['ls', 'echo'];
+
 /**
  * Normalize the provided configuration to a configuration which is easier to parse.
  *
@@ -232,9 +235,21 @@ function normalizeTerminalConfig(config?: TerminalSchema): NormalizedTerminalCon
 
   const panels: TerminalPanel[] = [];
 
+  const resolveAllowCommands = (allowCommands?: string[]): string[] | undefined => {
+    if (allowCommands === undefined) {
+      return DEFAULT_COMMANDS;
+    }
+
+    if (Array.isArray(allowCommands) && allowCommands.length === 0) {
+      return undefined;
+    }
+
+    return allowCommands;
+  };
+
   const options = {
     allowRedirects: config.allowRedirects,
-    allowCommands: config.allowCommands,
+    allowCommands: resolveAllowCommands(config.allowCommands),
   };
 
   if (config.panels) {
@@ -258,7 +273,7 @@ function normalizeTerminalConfig(config?: TerminalSchema): NormalizedTerminalCon
             id: panel.id,
             title: panel.title,
             allowRedirects: panel.allowRedirects ?? config.allowRedirects,
-            allowCommands: panel.allowCommands ?? config.allowCommands,
+            allowCommands: panel.allowCommands ?? DEFAULT_COMMANDS,
           });
         }
 


### PR DESCRIPTION
Change the default value of `terminal.allowCommands` from an empty array to `['ls', 'echo']`. This change prevents users from running all available commands by default in tutorials, enhancing security and focus. Lesson authors can still allow all commands by specifying `terminal.allowCommands: []` in the metadata.

BREAKING CHANGE: The default value of `terminal.allowCommands` is now restricted to `['ls', 'echo']`. To allow all commands, explicitly set `terminal.allowCommands: []` in the metadata.

Closes #302