### PR TITLE
feat(astro): override components to support `HeadTags`

### DIFF
--- a/docs/tutorialkit.dev/src/content/docs/guides/overriding-components.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/guides/overriding-components.mdx
@@ -91,13 +91,20 @@ interface Props {
 }
 ```
 
-### HeadLinks
+### HeadTags
 
 Component for overriding links in the head tag.
 
-When overriding `HeadLinks` you can place TutorialKit's default links using the `default-links` [Astro slot](https://docs.astro.build/en/basics/astro-components/#named-slots).
+When overriding `HeadTags` you can place TutorialKit's default components using following [Astro slots](https://docs.astro.build/en/basics/astro-components/#named-slots):
+
+- `title`: The page title
+- `links`: Links for the favicon, fonts and other assets
+- `meta`:  Metadata and Open Graph tags
 
 ```jsx title="src/components/CustomHeadLinks.astro"
-<slot name="default-links" />
+<slot name="title" />
+<slot name="links" />
+<slot name="meta" />
+{/** Add your own tags */}
 <link rel="sitemap" href="/sitemap-index.xml" />
 ```

--- a/docs/tutorialkit.dev/src/content/docs/guides/overriding-components.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/guides/overriding-components.mdx
@@ -93,7 +93,7 @@ interface Props {
 
 ### HeadTags
 
-Component for overriding links in the head tag.
+Component for overriding title, links and metadata in the `<head>` tag.
 
 When overriding `HeadTags` you can place TutorialKit's default components using following [Astro slots](https://docs.astro.build/en/basics/astro-components/#named-slots):
 

--- a/docs/tutorialkit.dev/src/content/docs/guides/overriding-components.mdx
+++ b/docs/tutorialkit.dev/src/content/docs/guides/overriding-components.mdx
@@ -90,3 +90,14 @@ interface Props {
   children: ReactNode;
 }
 ```
+
+### HeadLinks
+
+Component for overriding links in the head tag.
+
+When overriding `HeadLinks` you can place TutorialKit's default links using the `default-links` [Astro slot](https://docs.astro.build/en/basics/astro-components/#named-slots).
+
+```jsx title="src/components/CustomHeadLinks.astro"
+<slot name="default-links" />
+<link rel="sitemap" href="/sitemap-index.xml" />
+```

--- a/e2e/configs/override-components.ts
+++ b/e2e/configs/override-components.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       components: {
         Dialog: './src/components/Dialog.tsx',
         TopBar: './src/components/TopBar.astro',
-        HeadLinks: './src/components/HeadLinks.astro',
+        HeadTags: './src/components/CustomHeadTags.astro',
       },
     }),
   ],

--- a/e2e/configs/override-components.ts
+++ b/e2e/configs/override-components.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       components: {
         Dialog: './src/components/Dialog.tsx',
         TopBar: './src/components/TopBar.astro',
+        HeadLinks: './src/components/HeadLinks.astro',
       },
     }),
   ],

--- a/e2e/src/components/CustomHeadTags.astro
+++ b/e2e/src/components/CustomHeadTags.astro
@@ -1,4 +1,5 @@
 <slot name="title" />
 <slot name="links" />
 <slot name="meta" />
+<meta name="e2e-test-custom-meta-tag" content="custom-content" />
 <link rel="sitemap" href="/sitemap-index.xml" />

--- a/e2e/src/components/CustomHeadTags.astro
+++ b/e2e/src/components/CustomHeadTags.astro
@@ -1,0 +1,4 @@
+<slot name="title" />
+<slot name="links" />
+<slot name="meta" />
+<link rel="sitemap" href="/sitemap-index.xml" />

--- a/e2e/test/headtags.override-components.test.ts
+++ b/e2e/test/headtags.override-components.test.ts
@@ -8,7 +8,10 @@ test('developer can override HeadTags', async ({ page }) => {
     page.locator('meta[name="og:title"]'),
     page.locator('link[rel="stylesheet"]').first(),
   ];
-  const customElems = [page.locator('link[rel="sitemap"]')];
+  const customElems = [
+    page.locator('meta[name="e2e-test-custom-meta-tag"][content="custom-content"]'),
+    page.locator('link[rel="sitemap"]'),
+  ];
 
   for (const e of defaultElems) {
     await expect(e).toBeAttached();

--- a/e2e/test/headtags.override-components.test.ts
+++ b/e2e/test/headtags.override-components.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test('developer can override HeadTags', async ({ page }) => {
+  await page.goto('/');
+
+  const defaultElems = [
+    page.locator('title'),
+    page.locator('meta[name="og:title"]'),
+    page.locator('link[rel="stylesheet"]').first(),
+  ];
+  const customElems = [page.locator('link[rel="sitemap"]')];
+
+  for (const e of defaultElems) {
+    await expect(e).toBeAttached();
+  }
+
+  for (const e of customElems) {
+    await expect(e).toBeAttached();
+  }
+});

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -20,7 +20,7 @@
     "./default/pages/index.astro": "./dist/default/pages/index.astro",
     "./default/pages/[...slug].astro": "./dist/default/pages/[...slug].astro",
     "./default/components/TopBar.astro": "./dist/default/components/TopBar.astro",
-    "./default/components/HeadLinks.astro": "./dist/default/components/HeadLinks.astro",
+    "./default/components/HeadTags.astro": "./dist/default/components/HeadTags.astro",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -20,6 +20,7 @@
     "./default/pages/index.astro": "./dist/default/pages/index.astro",
     "./default/pages/[...slug].astro": "./dist/default/pages/[...slug].astro",
     "./default/components/TopBar.astro": "./dist/default/components/TopBar.astro",
+    "./default/components/HeadLinks.astro": "./dist/default/components/HeadLinks.astro",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/astro/src/default/components/HeadLinks.astro
+++ b/packages/astro/src/default/components/HeadLinks.astro
@@ -1,0 +1,1 @@
+<slot name="default-links" />

--- a/packages/astro/src/default/components/HeadLinks.astro
+++ b/packages/astro/src/default/components/HeadLinks.astro
@@ -1,1 +1,0 @@
-<slot name="default-links" />

--- a/packages/astro/src/default/components/HeadTags.astro
+++ b/packages/astro/src/default/components/HeadTags.astro
@@ -1,0 +1,3 @@
+<slot name="title" />
+<slot name="links" />
+<slot name="meta" />

--- a/packages/astro/src/default/env-default.d.ts
+++ b/packages/astro/src/default/env-default.d.ts
@@ -12,7 +12,7 @@ declare module 'tutorialkit:override-components' {
   const headTags: typeof import('./src/default/components/HeadTags.astro').default;
   const dialog: typeof import('@tutorialkit/react/dialog').default;
 
-  export { topBar as TopBar, dialog as Dialog, headLinks as HeadTags };
+  export { topBar as TopBar, dialog as Dialog, headTags as HeadTags };
 }
 
 declare const __ENTERPRISE__: boolean;

--- a/packages/astro/src/default/env-default.d.ts
+++ b/packages/astro/src/default/env-default.d.ts
@@ -9,9 +9,10 @@ interface WebContainerConfig {
 
 declare module 'tutorialkit:override-components' {
   const topBar: typeof import('./src/default/components/TopBar.astro').default;
+  const headLinks: typeof import('./src/default/components/HeadLinks.astro').default;
   const dialog: typeof import('@tutorialkit/react/dialog').default;
 
-  export { topBar as TopBar, dialog as Dialog };
+  export { topBar as TopBar, dialog as Dialog, headLinks as HeadLinks };
 }
 
 declare const __ENTERPRISE__: boolean;

--- a/packages/astro/src/default/env-default.d.ts
+++ b/packages/astro/src/default/env-default.d.ts
@@ -9,7 +9,7 @@ interface WebContainerConfig {
 
 declare module 'tutorialkit:override-components' {
   const topBar: typeof import('./src/default/components/TopBar.astro').default;
-  const headLinks: typeof import('./src/default/components/HeadTags.astro').default;
+  const headTags: typeof import('./src/default/components/HeadTags.astro').default;
   const dialog: typeof import('@tutorialkit/react/dialog').default;
 
   export { topBar as TopBar, dialog as Dialog, headLinks as HeadTags };

--- a/packages/astro/src/default/env-default.d.ts
+++ b/packages/astro/src/default/env-default.d.ts
@@ -9,10 +9,10 @@ interface WebContainerConfig {
 
 declare module 'tutorialkit:override-components' {
   const topBar: typeof import('./src/default/components/TopBar.astro').default;
-  const headLinks: typeof import('./src/default/components/HeadLinks.astro').default;
+  const headLinks: typeof import('./src/default/components/HeadTags.astro').default;
   const dialog: typeof import('@tutorialkit/react/dialog').default;
 
-  export { topBar as TopBar, dialog as Dialog, headLinks as HeadLinks };
+  export { topBar as TopBar, dialog as Dialog, headLinks as HeadTags };
 }
 
 declare const __ENTERPRISE__: boolean;

--- a/packages/astro/src/default/layouts/Layout.astro
+++ b/packages/astro/src/default/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-import { HeadLinks } from 'tutorialkit:override-components';
+import { HeadTags } from 'tutorialkit:override-components';
 import { ViewTransitions } from 'astro:transitions';
 import type { MetaTagsConfig } from '@tutorialkit/types';
 import MetaTags from '../components/MetaTags.astro';
@@ -16,11 +16,10 @@ const faviconUrl = readPublicAsset('favicon.svg');
 <!doctype html>
 <html lang="en" transition:animate="none" class="h-full overflow-hidden">
   <head>
-    <title>{title}</title>
-    {faviconUrl ? <link rel="icon" type="image/svg+xml" href={faviconUrl} /> : null}
-    <MetaTags meta={meta} />
-    <HeadLinks>
-      <Fragment slot="default-links">
+    <HeadTags>
+      <title slot="title">{title}</title>
+      <Fragment slot="links">
+        {faviconUrl ? <link rel="icon" type="image/svg+xml" href={faviconUrl} /> : null}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link
@@ -29,7 +28,8 @@ const faviconUrl = readPublicAsset('favicon.svg');
         />
         <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet" />
       </Fragment>
-    </HeadLinks>
+      <MetaTags slot="meta" meta={meta} />
+    </HeadTags>
     <ViewTransitions />
     <script is:inline>
       setTutorialKitTheme();

--- a/packages/astro/src/default/layouts/Layout.astro
+++ b/packages/astro/src/default/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import { HeadLinks } from 'tutorialkit:override-components';
 import { ViewTransitions } from 'astro:transitions';
 import type { MetaTagsConfig } from '@tutorialkit/types';
 import MetaTags from '../components/MetaTags.astro';
@@ -18,10 +19,17 @@ const faviconUrl = readPublicAsset('favicon.svg');
     <title>{title}</title>
     {faviconUrl ? <link rel="icon" type="image/svg+xml" href={faviconUrl} /> : null}
     <MetaTags meta={meta} />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet" />
+    <HeadLinks>
+      <Fragment slot="default-links">
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+          rel="stylesheet"
+        />
+        <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet" />
+      </Fragment>
+    </HeadLinks>
     <ViewTransitions />
     <script is:inline>
       setTutorialKitTheme();

--- a/packages/astro/src/default/layouts/Layout.astro
+++ b/packages/astro/src/default/layouts/Layout.astro
@@ -29,6 +29,7 @@ const faviconUrl = readPublicAsset('favicon.svg');
         />
         <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet" />
       </Fragment>
+
       <MetaTags slot="meta" meta={meta} />
     </HeadTags>
     <ViewTransitions />

--- a/packages/astro/src/default/layouts/Layout.astro
+++ b/packages/astro/src/default/layouts/Layout.astro
@@ -18,6 +18,7 @@ const faviconUrl = readPublicAsset('favicon.svg');
   <head>
     <HeadTags>
       <title slot="title">{title}</title>
+
       <Fragment slot="links">
         {faviconUrl ? <link rel="icon" type="image/svg+xml" href={faviconUrl} /> : null}
         <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/packages/astro/src/vite-plugins/override-components.ts
+++ b/packages/astro/src/vite-plugins/override-components.ts
@@ -96,7 +96,7 @@ export function overrideComponents({ components, defaultRoutes }: Options): Vite
         return `
           export { default as TopBar } from '${topBar}';
           export { default as Dialog } from '${dialog}';
-          export { default as HeadTags } from '${headLinks}';
+          export { default as HeadTags } from '${headTags}';
         `;
       }
 

--- a/packages/astro/src/vite-plugins/override-components.ts
+++ b/packages/astro/src/vite-plugins/override-components.ts
@@ -18,7 +18,7 @@
  *       components: {
  *         TopBar: './CustomTopBar.astro',
  *         Dialog: './CustomDialog.tsx',
- *         HeadLinks: './CustomHeadLinks.astro',
+ *         HeadTags: './CustomHeadLinks.astro',
  *       },
  *     }),
  *   ],
@@ -66,7 +66,7 @@ export interface OverrideComponentsOptions {
    * <link rel="sitemap" href="/sitemap-index.xml" />
    * ```
    */
-  HeadLinks: string;
+  HeadTags: string;
 }
 
 interface Options {
@@ -90,13 +90,13 @@ export function overrideComponents({ components, defaultRoutes }: Options): Vite
     async load(id) {
       if (id === resolvedId) {
         const topBar = components?.TopBar || resolveDefaultTopBar(defaultRoutes);
-        const headLinks = components?.HeadLinks || resolveDefaultHeadLinks(defaultRoutes);
+        const headLinks = components?.HeadTags || resolveDefaultHeadLinks(defaultRoutes);
         const dialog = components?.Dialog || '@tutorialkit/react/dialog';
 
         return `
           export { default as TopBar } from '${topBar}';
           export { default as Dialog } from '${dialog}';
-          export { default as HeadLinks } from '${headLinks}';
+          export { default as HeadTags } from '${headLinks}';
         `;
       }
 
@@ -116,9 +116,9 @@ function resolveDefaultTopBar(defaultRoutes: boolean) {
 
 function resolveDefaultHeadLinks(defaultRoutes: boolean) {
   if (defaultRoutes) {
-    return '@tutorialkit/astro/default/components/HeadLinks.astro';
+    return '@tutorialkit/astro/default/components/HeadTags.astro';
   }
 
-  // default `HeadLinks` is used from local file when `defaultRoutes` is disabled
-  return './src/components/HeadLinks.astro';
+  // default `HeadTags` is used from local file when `defaultRoutes` is disabled
+  return './src/components/HeadTags.astro';
 }

--- a/packages/astro/src/vite-plugins/override-components.ts
+++ b/packages/astro/src/vite-plugins/override-components.ts
@@ -114,7 +114,7 @@ function resolveDefaultTopBar(defaultRoutes: boolean) {
   return './src/components/TopBar.astro';
 }
 
-function resolveDefaultHeadLinks(defaultRoutes: boolean) {
+function resolveDefaultHeadTags(defaultRoutes: boolean) {
   if (defaultRoutes) {
     return '@tutorialkit/astro/default/components/HeadTags.astro';
   }

--- a/packages/astro/src/vite-plugins/override-components.ts
+++ b/packages/astro/src/vite-plugins/override-components.ts
@@ -18,6 +18,7 @@
  *       components: {
  *         TopBar: './CustomTopBar.astro',
  *         Dialog: './CustomDialog.tsx',
+ *         HeadLinks: './CustomHeadLinks.astro',
  *       },
  *     }),
  *   ],
@@ -54,6 +55,18 @@ export interface OverrideComponentsOptions {
    * It will receive same props that `@tutorialkit/react/dialog` supports.
    */
   Dialog?: string;
+
+  /**
+   * Component for overriding links in the head tag.
+   *
+   * It will receive TutorialKit default links within the "default-links" slot.
+   *
+   * ```jsx
+   * <slot name="default-links"></slot>
+   * <link rel="sitemap" href="/sitemap-index.xml" />
+   * ```
+   */
+  HeadLinks: string;
 }
 
 interface Options {
@@ -77,11 +90,13 @@ export function overrideComponents({ components, defaultRoutes }: Options): Vite
     async load(id) {
       if (id === resolvedId) {
         const topBar = components?.TopBar || resolveDefaultTopBar(defaultRoutes);
+        const headLinks = components?.HeadLinks || resolveDefaultHeadLinks(defaultRoutes);
         const dialog = components?.Dialog || '@tutorialkit/react/dialog';
 
         return `
           export { default as TopBar } from '${topBar}';
           export { default as Dialog } from '${dialog}';
+          export { default as HeadLinks } from '${headLinks}';
         `;
       }
 
@@ -97,4 +112,13 @@ function resolveDefaultTopBar(defaultRoutes: boolean) {
 
   // default `TopBar` is used from local file when `defaultRoutes` is disabled
   return './src/components/TopBar.astro';
+}
+
+function resolveDefaultHeadLinks(defaultRoutes: boolean) {
+  if (defaultRoutes) {
+    return '@tutorialkit/astro/default/components/HeadLinks.astro';
+  }
+
+  // default `HeadLinks` is used from local file when `defaultRoutes` is disabled
+  return './src/components/HeadLinks.astro';
 }

--- a/packages/astro/src/vite-plugins/override-components.ts
+++ b/packages/astro/src/vite-plugins/override-components.ts
@@ -90,7 +90,7 @@ export function overrideComponents({ components, defaultRoutes }: Options): Vite
     async load(id) {
       if (id === resolvedId) {
         const topBar = components?.TopBar || resolveDefaultTopBar(defaultRoutes);
-        const headLinks = components?.HeadTags || resolveDefaultHeadLinks(defaultRoutes);
+        const headTags = components?.HeadTags || resolveDefaultHeadTags(defaultRoutes);
         const dialog = components?.Dialog || '@tutorialkit/react/dialog';
 
         return `

--- a/packages/astro/src/vite-plugins/override-components.ts
+++ b/packages/astro/src/vite-plugins/override-components.ts
@@ -57,13 +57,18 @@ export interface OverrideComponentsOptions {
   Dialog?: string;
 
   /**
-   * Component for overriding links in the head tag.
+   * Component for overriding title, links and metadata in the `<head>` tag.
    *
-   * It will receive TutorialKit default links within the "default-links" slot.
+   * This component has slots that are used to pass TutorialKit's default tags:
+   *
+   * - `title`: The page title
+   * - `links`: Links for the favicon, fonts and other assets
+   * - `meta`:  Metadata and Open Graph tags
    *
    * ```jsx
-   * <slot name="default-links"></slot>
-   * <link rel="sitemap" href="/sitemap-index.xml" />
+   * <slot name="title" />
+   * <slot name="links" />
+   * <slot name="meta" />
    * ```
    */
   HeadTags: string;

--- a/packages/cli/tests/__snapshots__/create-tutorial.test.ts.snap
+++ b/packages/cli/tests/__snapshots__/create-tutorial.test.ts.snap
@@ -235,6 +235,7 @@ exports[`create and eject a project 1`] = `
   "public/logo.svg",
   "src",
   "src/components",
+  "src/components/HeadTags.astro",
   "src/components/LoginButton.tsx",
   "src/components/Logo.astro",
   "src/components/MainContainer.astro",


### PR DESCRIPTION
I was investigating setting up a sitemap, using [@astrojs/sitemap](https://docs.astro.build/en/guides/integrations-guide/sitemap/).
For a proper setup, you also want to add a `link` tag in the page `head` to tell scrapers the URL to your sitemap (in addition to robot.txt). We could do this in the framework default setup, but that would mean setting up `sitemap` as an integration there and I'd rather give end users more control on the configuration.

So I went down the rabbit hole and implemented a replaceable `HeadTags` component.

I've tried to make the API as future proof as possible using slots.
