### PR TITLE
fix(astro): types of override components to optional

### DIFF
--- a/packages/astro/src/vite-plugins/override-components.ts
+++ b/packages/astro/src/vite-plugins/override-components.ts
@@ -71,7 +71,7 @@ export interface OverrideComponentsOptions {
    * <slot name="meta" />
    * ```
    */
-  HeadTags: string;
+  HeadTags?: string;
 }
 
 interface Options {


### PR DESCRIPTION
- Related to https://github.com/stackblitz/tutorialkit/pull/375

All keys of `components` should be optional. 

```
18:30:26.671 | > astro check && astro build
18:30:26.671 |  
18:30:30.516 | ✘ [ERROR] The build was canceled
18:30:30.516 |  
18:30:30.519 | 15:30:30 [types] Generated 1.71s
18:30:30.526 | 15:30:30 [check] Getting diagnostics for Astro files in /opt/buildhome/repo...
18:30:32.992 | astro.config.ts:10:7 - error ts(2741): Property 'HeadTags' is missing in type '{ TopBar: string; }' but required in type 'OverrideComponentsOptions'.
18:30:32.993 |  
18:30:32.993 | 10       components: {
18:30:32.993 | ~~~~~~~~~~
18:30:32.993
```


