### PR TITLE
fix(deps): move `react` & `react-dom` to peer dependencies

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -56,8 +56,6 @@
     "mdast-util-directive": "^3.0.0",
     "mdast-util-to-markdown": "^2.1.0",
     "nanostores": "^0.10.3",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
     "remark-directive": "^3.0.0",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
@@ -70,11 +68,15 @@
     "esbuild": "^0.20.2",
     "esbuild-node-externals": "^1.13.1",
     "execa": "^9.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "typescript": "^5.4.5",
     "vite-plugin-inspect": "0.8.4",
     "vitest": "^2.1.1"
   },
   "peerDependencies": {
-    "astro": "^4.15.0"
+    "astro": "^4.15.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -93,7 +93,6 @@
     "framer-motion": "^11.2.11",
     "nanostores": "^0.10.3",
     "picomatch": "^4.0.2",
-    "react": "^18.3.1",
     "react-resizable-panels": "^2.0.19"
   },
   "devDependencies": {
@@ -103,7 +102,11 @@
     "@types/react": "^18.3.3",
     "chokidar": "3.6.0",
     "execa": "^9.2.0",
+    "react": "^18.3.1",
     "typescript": "^5.4.5",
     "vitest": "^2.1.1"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,12 +356,6 @@ importers:
       nanostores:
         specifier: ^0.10.3
         version: 0.10.3
-      react:
-        specifier: ^18.3.1
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
       remark-directive:
         specifier: ^3.0.0
         version: 3.0.0
@@ -390,6 +384,12 @@ importers:
       execa:
         specifier: ^9.2.0
         version: 9.2.0
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       typescript:
         specifier: ^5.4.5
         version: 5.5.3
@@ -584,9 +584,6 @@ importers:
       picomatch:
         specifier: ^4.0.2
         version: 4.0.2
-      react:
-        specifier: ^18.3.1
-        version: 18.3.1
       react-resizable-panels:
         specifier: ^2.0.19
         version: 2.0.19(react-dom@18.3.1)(react@18.3.1)
@@ -609,6 +606,9 @@ importers:
       execa:
         specifier: ^9.2.0
         version: 9.2.0
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
       typescript:
         specifier: ^5.4.5
         version: 5.5.3
@@ -4012,7 +4012,7 @@ packages:
       '@unocss/core': 0.59.4
       '@unocss/reset': 0.59.4
       '@unocss/vite': 0.59.4(vite@5.4.2)
-      vite: 5.4.2(@types/node@22.4.2)
+      vite: 5.4.2(@types/node@22.4.2)(sass@1.77.6)
     transitivePeerDependencies:
       - rollup
 
@@ -4211,7 +4211,7 @@ packages:
       chokidar: 3.6.0
       fast-glob: 3.3.2
       magic-string: 0.30.11
-      vite: 5.4.2(@types/node@22.4.2)
+      vite: 5.4.2(@types/node@22.4.2)(sass@1.77.6)
     transitivePeerDependencies:
       - rollup
 
@@ -6742,7 +6742,6 @@ packages:
 
   /immutable@4.3.6:
     resolution: {integrity: sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==}
-    dev: true
 
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -8835,7 +8834,6 @@ packages:
       chokidar: 3.6.0
       immutable: 4.3.6
       source-map-js: 1.2.0
-    dev: true
 
   /sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
@@ -9644,7 +9642,7 @@ packages:
       '@unocss/transformer-directives': 0.59.4
       '@unocss/transformer-variant-group': 0.59.4
       '@unocss/vite': 0.59.4(vite@5.4.2)
-      vite: 5.4.2(@types/node@22.4.2)
+      vite: 5.4.2(@types/node@22.4.2)(sass@1.77.6)
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -9990,7 +9988,6 @@ packages:
       sass: 1.77.6
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vitefu@0.2.5(vite@5.4.2):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}


### PR DESCRIPTION
Let's see if this fixes "Invalid hook call" errors caused when custom components are used in mdx-files.