### PR TITLE
fix(react): add vertical scroll bar to editor file tree

### DIFF
--- a/packages/react/src/Panels/EditorPanel.tsx
+++ b/packages/react/src/Panels/EditorPanel.tsx
@@ -79,7 +79,7 @@ export function EditorPanel({
           </div>
         </div>
         <FileTree
-          className="flex-grow py-2 border-r border-tk-elements-app-borderColor text-sm overflow-y-auto overflow-x-hidden"
+          className="flex flex-col flex-grow py-2 border-r border-tk-elements-app-borderColor text-sm overflow-y-auto overflow-x-hidden"
           i18n={i18n}
           selectedFile={selectedFile}
           hideRoot={hideRoot ?? true}

--- a/packages/react/src/Panels/EditorPanel.tsx
+++ b/packages/react/src/Panels/EditorPanel.tsx
@@ -79,7 +79,7 @@ export function EditorPanel({
           </div>
         </div>
         <FileTree
-          className="flex-grow py-2 border-r border-tk-elements-app-borderColor text-sm"
+          className="flex-grow py-2 border-r border-tk-elements-app-borderColor text-sm overflow-y-auto overflow-x-hidden"
           i18n={i18n}
           selectedFile={selectedFile}
           hideRoot={hideRoot ?? true}

--- a/packages/react/src/core/FileTree.tsx
+++ b/packages/react/src/core/FileTree.tsx
@@ -125,7 +125,7 @@ export function FileTree({
         directory=""
         onFileChange={onFileChange}
         allowEditPatterns={allowEditPatterns}
-        triggerProps={{ className: 'h-full', 'data-testid': 'file-tree-root-context-menu' }}
+        triggerProps={{ className: 'h-full min-h-4', 'data-testid': 'file-tree-root-context-menu' }}
       />
     </div>
   );


### PR DESCRIPTION
Small ui fix that adds `overflow-y: auto` to the editor file tree for when there are more files than fit in the editor panel

Before:
![Screenshot 2024-10-30 at 7 07 12 PM](https://github.com/user-attachments/assets/d6aea6ce-b6ee-4771-8fe2-447132776ca6)

After:
![Screenshot 2024-10-30 at 7 06 15 PM](https://github.com/user-attachments/assets/19efd390-257c-43ee-b440-ab4c2e48349f)
