### PR TITLE
fix: remove `downloadAsZip` from template for now

### DIFF
--- a/packages/cli/overwrites/src/content/tutorial/meta.md
+++ b/packages/cli/overwrites/src/content/tutorial/meta.md
@@ -3,5 +3,4 @@ type: tutorial
 mainCommand: ['npm run dev', 'Starting http server']
 prepareCommands:
   - ['npm install', 'Installing dependencies']
-downloadAsZip: true
 ---


### PR DESCRIPTION
- Integration tests use latest published version so they are failing now that template contains new keyword. Let's add this back after release. 