### PR TITLE
feat(dev): add support for footer override

### DIFF
--- a/packages/astro/src/default/components/Footer.astro
+++ b/packages/astro/src/default/components/Footer.astro
@@ -1,0 +1,13 @@
+<nav
+  class="bg-tk-elements-footer-backgroundColor border-t border-tk-elements-app-borderColor flex justify-between p-4"
+>
+  <div class="flex-1">
+    <slot name="terms" />
+  </div>
+  <div class="flex-1">
+    <slot name="contact-info" />
+  </div>
+  <div class="flex-1">
+    <slot name="copyright" />
+  </div>
+</nav>

--- a/packages/astro/src/default/components/FooterWrapper.astro
+++ b/packages/astro/src/default/components/FooterWrapper.astro
@@ -1,0 +1,14 @@
+---
+// FooterWrapper.astro
+import { Footer } from 'tutorialkit:override-components';
+import Terms from './Terms.astro';
+import ContactInfo from './ContactInfo.astro';
+
+const currentYear = new Date().getFullYear();
+---
+
+<Footer>
+  <Terms slot="terms" />
+  <ContactInfo slot="contact-info" />
+  <p slot="copyright">© {currentYear} Your Company. All rights reserved.</p>
+</Footer>


### PR DESCRIPTION
adds support for overriding the footer component, similar to the TopBar override setup. Users can now customize footer content such as legal terms, contact info, and copyrights.

this change introduces `Footer.astro` and `FooterWrapper.astro` files to allow flexible slotting of footer items, improving customization for standalone tutorial deployments

close #323