### PR TITLE
fix: switch default `meta.image` to `.png`

### DIFF
--- a/packages/astro/src/default/components/MetaTags.astro
+++ b/packages/astro/src/default/components/MetaTags.astro
@@ -6,21 +6,27 @@ import { readPublicAsset } from '../utils/publicAsset';
 interface Props {
   meta?: MetaTagsConfig;
 }
+
+const DEFAULT_OG_IMAGE = 'https://tutorialkit.dev/tutorialkit-opengraph.png';
+
 const { meta = {} } = Astro.props;
 let imageUrl = meta.image;
 
+// Resolve relative paths to /public folder
 if (imageUrl?.startsWith('/') || imageUrl?.startsWith('.')) {
   imageUrl = readPublicAsset(imageUrl, true);
 
   if (!imageUrl) {
-    console.warn(`Image ${meta.image} not found in "/public" folder`);
+    console.warn(`\nImage ${meta.image} not found in "/public" folder`);
   }
 }
 
-imageUrl ??= readLogoFile('logo', true);
+imageUrl ??= DEFAULT_OG_IMAGE;
+
 if (imageUrl?.endsWith('.svg')) {
-  console.warn(`Using a SVG open graph image "${imageUrl}". This is not supported by most social platforms. 
-  You should rather set "meta.image" to a raster image (PNG, WEBP).`);
+  console.warn(
+    `\nUsing a SVG open graph image "${imageUrl}". This is not supported by most social platforms. You should rather set "meta.image" to a raster image (PNG, WEBP).`,
+  );
 }
 ---
 


### PR DESCRIPTION
- Continues https://github.com/stackblitz/tutorialkit/pull/377

Currently used default `logo.svg` og-image does not show up in most social platforms. Let's use hosted `.png` one: `'https://tutorialkit.dev/tutorialkit-opengraph.png'`.