### PR TITLE
feat(astro): add sensible default canonical url

### DIFF
--- a/packages/astro/src/default/layouts/Layout.astro
+++ b/packages/astro/src/default/layouts/Layout.astro
@@ -11,6 +11,7 @@ interface Props {
 }
 const { title, meta } = Astro.props;
 const faviconUrl = readPublicAsset('favicon.svg');
+const canonicalUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site).toString() : null;
 ---
 
 <!doctype html>
@@ -20,6 +21,7 @@ const faviconUrl = readPublicAsset('favicon.svg');
       <title slot="title">{title}</title>
 
       <Fragment slot="links">
+        {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
         {faviconUrl ? <link rel="icon" type="image/svg+xml" href={faviconUrl} /> : null}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
I got deindexed by Google due to the lack of a proper canonical link, so here is a small update to set it up when the website has a configured absolute URL.

![image](https://github.com/user-attachments/assets/7fd8a1a3-d7ed-4c85-81af-b17460a95a53)

The PR just needs a double check because I was running the demo code which doesn't have an astro.config so no Astro.site.

Current palliative is to setup a custom HeadTags.