### PR TITLE
feat(astro): custom expressive code plugins

### DIFF
--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import type { AstroConfig, AstroIntegration } from 'astro';
+import type { ExpressiveCodePlugin } from 'astro-expressive-code';
 import { extraIntegrations } from './integrations.js';
 import { updateMarkdownConfig } from './remark/index.js';
 import { tutorialkitCore } from './vite-plugins/core.js';
@@ -59,6 +60,13 @@ export interface Options {
      */
     scope: string;
   };
+
+  /**
+   * Expressive code plugins.
+   *
+   * @default []
+   */
+  expressiveCodePlugins?: ExpressiveCodePlugin[];
 }
 
 export default function createPlugin({
@@ -66,6 +74,7 @@ export default function createPlugin({
   components,
   isolation,
   enterprise,
+  expressiveCodePlugins = [],
 }: Options = {}): AstroIntegration {
   const webcontainerFiles = new WebContainerFiles();
 
@@ -137,7 +146,11 @@ export default function createPlugin({
 
         // inject the additional integrations right after ours
         const selfIndex = config.integrations.findIndex((integration) => integration.name === '@tutorialkit/astro');
-        config.integrations.splice(selfIndex + 1, 0, ...extraIntegrations({ root: fileURLToPath(config.root) }));
+        config.integrations.splice(
+          selfIndex + 1,
+          0,
+          ...extraIntegrations({ root: fileURLToPath(config.root), expressiveCodePlugins }),
+        );
       },
       'astro:config:done'({ config }) {
         _config = config;

--- a/packages/astro/src/integrations.ts
+++ b/packages/astro/src/integrations.ts
@@ -4,14 +4,20 @@ import react from '@astrojs/react';
 import { pluginCollapsibleSections } from '@expressive-code/plugin-collapsible-sections';
 import { pluginLineNumbers } from '@expressive-code/plugin-line-numbers';
 import { getInlineContentForPackage } from '@tutorialkit/theme';
-import expressiveCode from 'astro-expressive-code';
+import expressiveCode, { type ExpressiveCodePlugin } from 'astro-expressive-code';
 import UnoCSS from 'unocss/astro';
 
-export function extraIntegrations({ root }: { root: string }) {
+export function extraIntegrations({
+  root,
+  expressiveCodePlugins = [],
+}: {
+  root: string;
+  expressiveCodePlugins?: ExpressiveCodePlugin[];
+}) {
   return [
     react(),
     expressiveCode({
-      plugins: [pluginCollapsibleSections(), pluginLineNumbers()],
+      plugins: [pluginCollapsibleSections(), pluginLineNumbers(), ...expressiveCodePlugins],
       themes: ['dark-plus', 'light-plus'],
       customizeTheme: (theme) => {
         const isDark = theme.type === 'dark';


### PR DESCRIPTION
I would like to add custom expressive code plugins to change the way code blocks are rendered.

This PR adds an options `expressiveCodePlugins` property on the `tutorialkit` plugin that is instantiated in the `astro.config.ts`.