### PR TITLE
feat(astro): preserve file path for imported file code blocks

### DIFF
--- a/packages/astro/src/remark/import-file.ts
+++ b/packages/astro/src/remark/import-file.ts
@@ -48,6 +48,7 @@ export function remarkImportFilePlugin(options: RemarkImportFilePluginOptions) {
 
           if (content) {
             node.value = content;
+            node.meta ||= '';
             node.meta += ' path=' + node.lang;
             node.lang = path.extname(relativeFilePath).slice(1);
           }

--- a/packages/astro/src/remark/import-file.ts
+++ b/packages/astro/src/remark/import-file.ts
@@ -48,6 +48,7 @@ export function remarkImportFilePlugin(options: RemarkImportFilePluginOptions) {
 
           if (content) {
             node.value = content;
+            node.meta += ' path=' + node.lang;
             node.lang = path.extname(relativeFilePath).slice(1);
           }
         }


### PR DESCRIPTION
I would like to write an expressive code plugin that behaves differently for code blocks that were imported from the file system.  However, the import file logic removes all information about the file path before the expressive code plugins are called.

This change preserves that information so that expressive code plugins can access it.