### PR TITLE
fix: headers not matching the documentation

### DIFF
--- a/packages/cli/src/commands/create/hosting-config/vercel.json
+++ b/packages/cli/src/commands/create/hosting-config/vercel.json
@@ -5,10 +5,10 @@
       "headers": [
         {
           "key": "Cross-Origin-Embedder-Policy",
-          "value": "require-crop"
+          "value": "require-corp"
         },
         {
-          "key": "Cross-Origin-Embedder-Policy",
+          "key": "Cross-Origin-Opener-Policy",
           "value": "same-origin"
         }
       ]


### PR DESCRIPTION
## Description

The generated `vercel.json` file content includes wrong headers, not matching the ones from the documentation:

- there is a typo for the first header
- the key of the second one is copied from the first one