### PR TITLE
fix: use `meta.title` as default `<title>`

### DIFF
--- a/packages/astro/src/default/layouts/Layout.astro
+++ b/packages/astro/src/default/layouts/Layout.astro
@@ -18,7 +18,7 @@ const canonicalUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site).toStri
 <html lang="en" transition:animate="none" class="h-full overflow-hidden">
   <head>
     <HeadTags>
-      <title slot="title">{title}</title>
+      <title slot="title">{meta?.title || title}</title>
 
       <Fragment slot="links">
         {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}


### PR DESCRIPTION
Hey folks, long time no see!

After reviewing my sites SEO, I've noticed that the titles were not properly configured. Because TutorialKit also uses the title for navigation, it injects the chapter and part title too.

To sum it up the proposal
- if meta.title is set, use it in the `<title>` tag: it will be picked up by search engines. But also visible in the browser window, so we lose the display of the part and chapter.
- if not set, the `<title>` tag is just the navigational title `part / chapter /lesson`

Related but not included in this PR: I suspect `trailingSlash: "never"` is a reasonable default in the config, otherwise search engines might pick pages as duplicate. Might be worth an investigation.