### PR TITLE
docs: remove extra verb and correct pronoun

### DIFF
--- a/docs/demo/src/content/tutorial/1-forms-css/2-colors/2-progressbar/content.md
+++ b/docs/demo/src/content/tutorial/1-forms-css/2-colors/2-progressbar/content.md
@@ -12,7 +12,7 @@ template: default
 
 Although `accent-color` that we've set in the previous step already impacts this element, we can customize it even further!
 
-Let's start by setting removing the border from the element. As you do it, you will notice that it will also change other aspects of the default appearance, like the height and radius.
+Let's start by removing the border from the element. As you do that, you will notice that it will also change other aspects of the default appearance, like the height and radius.
 
 ```css add={2}
 progress {


### PR DESCRIPTION
"it" is used to refer to a previously used *noun*, but "that" can refer to an *idea* that was just described.  (There are exceptions,  of course, but this is the general pattern.)